### PR TITLE
chore: add .gitmodules for submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,11 @@
+[submodule "src/AriaCoda"]
+	path = src/AriaCoda
+	url = https://github.com/reedhedges/AriaCoda.git
+
+[submodule "src/movemaster_control"]
+	path = src/movemaster_control
+	url = https://github.com/mhar-vell/movemaster_control.git
+
+[submodule "src/sparton_ahrs8_driver"]
+	path = src/sparton_ahrs8_driver
+	url = https://github.com/mhar-vell/sparton_ahrs8_driver.git


### PR DESCRIPTION
## Summary

- Adds `.gitmodules` registrando `src/AriaCoda`, `src/movemaster_control` e `src/sparton_ahrs8_driver` como submodules git
- URLs HTTPS para evitar necessidade de SSH key em alvos de deploy (ex: NUC)
- Sem isso, `git clone` do b166er deixa esses diretórios vazios

## Test plan

- [ ] `git submodule update --init --recursive` clona os três pacotes corretamente
- [ ] Build na NUC funciona após o clone dos submodules

🤖 Generated with [Claude Code](https://claude.com/claude-code)