### PR TITLE
feat(t265): Intel RealSense T265 — udev rules e launch file

### DIFF
--- a/setup/udev_t265.sh
+++ b/setup/udev_t265.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Instala udev rules para a Intel RealSense T265.
+# Roda UMA VEZ em cada máquina (Shiroi e NUC) com a T265 conectada.
+# Uso: bash setup/udev_t265.sh
+
+set -euo pipefail
+
+RULES_FILE="/etc/udev/rules.d/99-realsense-t265.rules"
+
+echo "==> Instalando udev rules para Intel RealSense T265..."
+
+sudo tee "${RULES_FILE}" > /dev/null << 'EOF'
+# Intel RealSense T265 Tracking Camera
+# Vendor: Intel (8086), Product: T265 (0b37)
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="8086", ATTRS{idProduct}=="0b37", MODE="0666", GROUP="plugdev"
+# T265 em modo DFU
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="8086", ATTRS{idProduct}=="0b3a", MODE="0666", GROUP="plugdev"
+# Dispositivos HID associados (IMU interno)
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="8086", ATTRS{idProduct}=="0b52", MODE="0666", GROUP="plugdev"
+EOF
+
+echo "==> Adicionando usuário ao grupo plugdev..."
+sudo usermod -aG plugdev "${USER}"
+
+echo "==> Recarregando udev..."
+sudo udevadm control --reload-rules
+sudo udevadm trigger
+
+echo ""
+echo "======================================"
+echo " udev rules instaladas: ${RULES_FILE}"
+echo " Reconecte a T265 para aplicar."
+echo " (Re-login necessário para o grupo plugdev)"
+echo "======================================"

--- a/src/b166er_robot/launch/hardware/t265_hardware.launch
+++ b/src/b166er_robot/launch/hardware/t265_hardware.launch
@@ -1,0 +1,28 @@
+<launch>
+  <!-- Intel RealSense T265 Tracking Camera -->
+  <!-- Publica pose em /t265/odom/sample e TF camera_pose_frame -->
+
+  <arg name="camera"       default="t265"/>
+  <arg name="tf_prefix"    default=""/>
+  <arg name="publish_odom" default="true"/>
+
+  <node name="t265" pkg="realsense2_camera" type="realsense2_camera_node"
+        output="screen">
+    <param name="serial_no"           value=""/>
+    <param name="camera"              value="$(arg camera)"/>
+    <param name="tf_prefix"           value="$(arg tf_prefix)"/>
+
+    <!-- T265: habilita tracking, desabilita streams de profundidade -->
+    <param name="enable_pose"         value="true"/>
+    <param name="enable_fisheye1"     value="false"/>
+    <param name="enable_fisheye2"     value="false"/>
+    <param name="enable_accel"        value="true"/>
+    <param name="enable_gyro"         value="true"/>
+
+    <!-- Frequência de publicação da pose -->
+    <param name="pose_fps"            value="200"/>
+
+    <!-- Publica odometria como nav_msgs/Odometry -->
+    <param name="publish_odom_tf"     value="$(arg publish_odom)"/>
+  </node>
+</launch>


### PR DESCRIPTION
## Summary

- `setup/udev_t265.sh`: instala udev rules para a T265 (USB IDs `8086:0b37`, `0b3a`, `0b52`) e adiciona usuário ao grupo `plugdev`
- `src/b166er_robot/launch/hardware/t265_hardware.launch`: sobe o `realsense2_camera_node` com tracking de pose a 200Hz, acelerômetro e giroscópio habilitados
- Pacote instalado no `ros_env`: `ros-noetic-realsense2-camera` via robostack-noetic (usa `ros-noetic-librealsense2 2.50.0` — última versão com suporte à T265)

## Workflow

1. Rodar `bash setup/udev_t265.sh` em cada máquina (Shiroi e NUC)
2. Reconectar a T265
3. `roslaunch b166er_robot t265_hardware.launch`

## Test plan

- [ ] T265 reconhecida via USB sem permissão root
- [ ] `roslaunch b166er_robot t265_hardware.launch` publica `/t265/odom/sample`
- [ ] `rostopic hz /t265/odom/sample` mostra ~200Hz
- [ ] Repetir na NUC após merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)