### PR TITLE
fix(t265): corrige VID udev (8086→8087) e launch nodelet

### DIFF
--- a/setup/udev_t265.sh
+++ b/setup/udev_t265.sh
@@ -2,6 +2,10 @@
 # Instala udev rules para a Intel RealSense T265.
 # Roda UMA VEZ em cada máquina (Shiroi e NUC) com a T265 conectada.
 # Uso: bash setup/udev_t265.sh
+#
+# VIDs:
+#   03e7:2150 — Myriad VPU (bootloader antes do firmware)
+#   8087:0b37 — T265 modo operacional (pós-firmware)
 
 set -euo pipefail
 
@@ -10,13 +14,14 @@ RULES_FILE="/etc/udev/rules.d/99-realsense-t265.rules"
 echo "==> Instalando udev rules para Intel RealSense T265..."
 
 sudo tee "${RULES_FILE}" > /dev/null << 'EOF'
-# Intel RealSense T265 Tracking Camera
-# Vendor: Intel (8086), Product: T265 (0b37)
-SUBSYSTEMS=="usb", ATTRS{idVendor}=="8086", ATTRS{idProduct}=="0b37", MODE="0666", GROUP="plugdev"
+# Intel RealSense T265 Tracking Camera (modo operacional, VID=8087)
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="8087", ATTRS{idProduct}=="0b37", MODE:="0666", GROUP:="plugdev"
 # T265 em modo DFU
-SUBSYSTEMS=="usb", ATTRS{idVendor}=="8086", ATTRS{idProduct}=="0b3a", MODE="0666", GROUP="plugdev"
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="8087", ATTRS{idProduct}=="0b3a", MODE:="0666", GROUP:="plugdev"
 # Dispositivos HID associados (IMU interno)
-SUBSYSTEMS=="usb", ATTRS{idVendor}=="8086", ATTRS{idProduct}=="0b52", MODE="0666", GROUP="plugdev"
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="8087", ATTRS{idProduct}=="0b52", MODE:="0666", GROUP:="plugdev"
+# Myriad VPU (T265 pre-firmware, bootloader mode, VID=03e7)
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="03e7", ATTRS{idProduct}=="2150", MODE:="0666", GROUP:="plugdev"
 EOF
 
 echo "==> Adicionando usuário ao grupo plugdev..."

--- a/src/b166er_robot/launch/hardware/t265_hardware.launch
+++ b/src/b166er_robot/launch/hardware/t265_hardware.launch
@@ -1,28 +1,20 @@
 <launch>
   <!-- Intel RealSense T265 Tracking Camera -->
-  <!-- Publica pose em /t265/odom/sample e TF camera_pose_frame -->
+  <!-- Delega ao launch oficial do realsense2_camera (nodelet) -->
+  <!-- Publica: /t265/odom/sample, /t265/accel/sample, /t265/gyro/sample -->
 
-  <arg name="camera"       default="t265"/>
-  <arg name="tf_prefix"    default=""/>
-  <arg name="publish_odom" default="true"/>
+  <arg name="camera"          default="t265"/>
+  <arg name="serial_no"       default=""/>
+  <arg name="publish_odom_tf" default="true"/>
 
-  <node name="t265" pkg="realsense2_camera" type="realsense2_camera_node"
-        output="screen">
-    <param name="serial_no"           value=""/>
-    <param name="camera"              value="$(arg camera)"/>
-    <param name="tf_prefix"           value="$(arg tf_prefix)"/>
-
-    <!-- T265: habilita tracking, desabilita streams de profundidade -->
-    <param name="enable_pose"         value="true"/>
-    <param name="enable_fisheye1"     value="false"/>
-    <param name="enable_fisheye2"     value="false"/>
-    <param name="enable_accel"        value="true"/>
-    <param name="enable_gyro"         value="true"/>
-
-    <!-- Frequência de publicação da pose -->
-    <param name="pose_fps"            value="200"/>
-
-    <!-- Publica odometria como nav_msgs/Odometry -->
-    <param name="publish_odom_tf"     value="$(arg publish_odom)"/>
-  </node>
+  <include file="$(find realsense2_camera)/launch/rs_t265.launch">
+    <arg name="camera"          value="$(arg camera)"/>
+    <arg name="serial_no"       value="$(arg serial_no)"/>
+    <arg name="enable_pose"     value="true"/>
+    <arg name="enable_accel"    value="true"/>
+    <arg name="enable_gyro"     value="true"/>
+    <arg name="enable_fisheye1" value="false"/>
+    <arg name="enable_fisheye2" value="false"/>
+    <arg name="publish_odom_tf" value="$(arg publish_odom_tf)"/>
+  </include>
 </launch>


### PR DESCRIPTION
## Resumo

- **`setup/udev_t265.sh`**: VID `8086` → `8087` (o VID real da T265 no modo operacional pós-firmware); adiciona regra para Myriad VPU `03e7:2150` (modo bootloader); troca `=` por `:=` para travar mode/group contra override por regras posteriores
- **`src/b166er_robot/launch/hardware/t265_hardware.launch`**: o binário `realsense2_camera_node` não existe — o pacote é um nodelet. Substituído pelo include do `rs_t265.launch` oficial, que carrega o `RealSenseNodeFactory` via nodelet manager

## Root cause

`lsusb` mostrava `8087:0b37` mas as regras udev usavam `8086:0b37`. O VID `8086` é o ID PCI clássico da Intel; o VID USB da T265 é `8087`. Por isso a regra nunca batia e o librealsense recebia `RS2_USB_STATUS_ACCESS`.

## Resultado do teste (Shiroi)

```
Device with serial number 925122110468 was found.
Device USB type: 3.1
Tracking Module was found.
gyro stream is enabled - fps: 200
accel stream is enabled - fps: 62
pose stream is enabled - fps: 200
RealSense Node Is Up!
```

## Plano de teste

- [ ] Confirmar `ls -la /dev/bus/usb/002/XXX` → `crw-rw-rw- 1 root plugdev` após rodar `setup/udev_t265.sh` em nova máquina
- [ ] `roslaunch b166er_robot t265_hardware.launch` sem erros no Shiroi ✅
- [ ] Replicar na NUC após merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)