### PR TITLE
feat(setup): instala realsense2_camera automaticamente na NUC

### DIFF
--- a/setup/nuc_ros_setup.sh
+++ b/setup/nuc_ros_setup.sh
@@ -58,6 +58,12 @@ conda activate ros_env
 BASHRC
 fi
 
+# --- 6. Instala pacotes de hardware ---
+echo "==> Instalando ros-noetic-realsense2-camera (T265)..."
+"${MINIFORGE_DIR}/bin/mamba" install -n ros_env \
+  -c robostack-noetic \
+  ros-noetic-realsense2-camera -y
+
 echo ""
 echo "======================================"
 echo " ROS Noetic (RoboStack) configurado!"


### PR DESCRIPTION
## Resumo

- **`setup/nuc_ros_setup.sh`**: adiciona passo 6 que instala `ros-noetic-realsense2-camera` via `mamba` após criar o ambiente `ros_env`

## Motivação

Durante a replicação da T265 na NUC, o `roslaunch b166er_robot t265_hardware.launch` falhou com `Resource not found: realsense2_camera` — o pacote não estava no `ros_env.yml`. Instalação manual via `mamba install` resolveu. Este PR automatiza esse passo no script de setup para que futuras instalações da NUC não precisem de intervenção manual.

## Resultado

`setup/udev_t265.sh` + `setup/nuc_ros_setup.sh` são agora suficientes para configurar a T265 do zero em qualquer máquina nova.

🤖 Generated with [Claude Code](https://claude.com/claude-code)