### PR TITLE
feat(setup): ros_env.sh com fallback ZeroTier → mDNS

### DIFF
--- a/setup/ros_env.sh
+++ b/setup/ros_env.sh
@@ -2,22 +2,34 @@
 # Configura o ambiente ROS no notebook para usar a NUC como master.
 # Uso: source ~/b166er/setup/ros_env.sh
 #
-# A NUC deve estar acessível via mDNS (b166er-nuc.local) antes de executar.
+# Prioridade de conexão:
+#   1. ZeroTier (10.32.1.176) — funciona em qualquer rede com internet
+#   2. mDNS (b166er-nuc.local) — funciona na mesma LAN / AP direto
 
-NUC_HOST="b166er-nuc.local"
+NUC_ZEROTIER="10.32.1.176"
+NUC_MDNS="b166er-nuc.local"
+SHIROI_ZEROTIER="10.32.1.149"
 CONDA_ROS_PREFIX="$HOME/miniforge3/envs/ros_env"
 WORKSPACE_DEVEL="$HOME/b166er/devel/setup.bash"
 
-# Verifica se a NUC está acessível
-if ! ping -c 1 -W 2 "${NUC_HOST}" &>/dev/null; then
-  echo "[ros_env] AVISO: '${NUC_HOST}' não respondeu ao ping. Verifique a conexão."
+# Detecta qual rota está disponível
+if ping -c 1 -W 2 "${NUC_ZEROTIER}" &>/dev/null; then
+  NUC_HOST="${NUC_ZEROTIER}"
+  SHIROI_HOST="${SHIROI_ZEROTIER}"
+  echo "[ros_env] Usando ZeroTier (${NUC_ZEROTIER})"
+elif ping -c 1 -W 2 "${NUC_MDNS}" &>/dev/null; then
+  NUC_HOST="${NUC_MDNS}"
+  SHIROI_HOST="$(hostname).local"
+  echo "[ros_env] Usando mDNS (${NUC_MDNS})"
+else
+  echo "[ros_env] ERRO: NUC não encontrada via ZeroTier nem mDNS."
   return 1
 fi
 
 export ROS_MASTER_URI="http://${NUC_HOST}:11311"
-export ROS_HOSTNAME=$(hostname).local
-export ROS_IP=$(ip route get "$(getent hosts "${NUC_HOST}" | awk '{print $1}')" \
-              | awk '/src/{for(i=1;i<=NF;i++) if($i=="src") print $(i+1)}' | head -1)
+export ROS_HOSTNAME="${SHIROI_HOST}"
+export ROS_IP=$(ip route get "$(getent hosts "${NUC_HOST}" 2>/dev/null | awk '{print $1}' || echo "${NUC_HOST}")" \
+              2>/dev/null | awk '/src/{for(i=1;i<=NF;i++) if($i=="src") print $(i+1)}' | head -1)
 
 # Adiciona binários ROS ao PATH
 export PATH="${CONDA_ROS_PREFIX}/bin:${PATH}"


### PR DESCRIPTION
## Resumo

`setup/ros_env.sh` agora detecta automaticamente a melhor rota para a NUC:

1. **ZeroTier** (`10.32.1.176`) — tenta primeiro; funciona em qualquer rede com internet
2. **mDNS** (`b166er-nuc.local`) — fallback para LAN local / AP direto (b166er-net)

## IPs ZeroTier
- NUC: `10.32.1.176`
- Shiroi: `10.32.1.149`
- Rede: `743993800fd66fce`

## Resultado
`source setup/ros_env.sh` escolhe a rota correta automaticamente — sem reconfigurar ao trocar de laboratório.

🤖 Generated with [Claude Code](https://claude.com/claude-code)