### PR TITLE
feat(control): whole-body control Fase 1 — Pioneer + RV-M2 como sistema 8-DOF unificado

### DIFF
--- a/src/b166er_whole_body_control/CMakeLists.txt
+++ b/src/b166er_whole_body_control/CMakeLists.txt
@@ -35,5 +35,6 @@ catkin_package(
 
 catkin_install_python(PROGRAMS
   nodes/state_estimator.py
+  nodes/whole_body_planner.py
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )

--- a/src/b166er_whole_body_control/CMakeLists.txt
+++ b/src/b166er_whole_body_control/CMakeLists.txt
@@ -1,0 +1,39 @@
+cmake_minimum_required(VERSION 3.5)
+project(b166er_whole_body_control)
+
+find_package(catkin REQUIRED COMPONENTS
+  message_generation
+  std_msgs
+  geometry_msgs
+  nav_msgs
+  sensor_msgs
+)
+
+add_message_files(
+  FILES
+  RobotState.msg
+)
+
+generate_messages(
+  DEPENDENCIES
+  std_msgs
+  geometry_msgs
+  nav_msgs
+)
+
+catkin_package(
+  CATKIN_DEPENDS
+    message_runtime
+    rospy
+    std_msgs
+    geometry_msgs
+    nav_msgs
+    sensor_msgs
+    tf2_ros
+    tf2_geometry_msgs
+)
+
+catkin_install_python(PROGRAMS
+  nodes/state_estimator.py
+  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)

--- a/src/b166er_whole_body_control/CMakeLists.txt
+++ b/src/b166er_whole_body_control/CMakeLists.txt
@@ -36,5 +36,6 @@ catkin_package(
 catkin_install_python(PROGRAMS
   nodes/state_estimator.py
   nodes/whole_body_planner.py
+  nodes/fuzzy_wb_controller.py
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )

--- a/src/b166er_whole_body_control/launch/b166er_wb.launch
+++ b/src/b166er_whole_body_control/launch/b166er_wb.launch
@@ -1,0 +1,138 @@
+<launch>
+  <!--
+  ═══════════════════════════════════════════════════════════════════════
+  b166er Whole-Body Control — Launch Unificado (Fase 1)
+
+  Grafo de nós:
+
+    [t265_hardware]          [pioneer_hardware]    [movemaster_hardware]
+          |                        |                       |
+   /t265/odom/sample       /pioneer/pose          /joint_states (RV-M2)
+          |                        |                       |
+          └──────────┬─────────────┘                       |
+                     ▼                                     |
+             [state_estimator]                             |
+              (IK → q_arm_est)                             |
+                     |                                     |
+                     ▼                                     |
+              /b166er/robot_state                          |
+                     |                                     |
+  /b166er/ee_target ─┤                                     |
+                     ▼                                     |
+          [fuzzy_wb_controller]                            |
+             (Mamdani + J_wb)                              |
+            /          \                                   |
+       /cmd_vel    /b166er/arm_vel_cmd                     |
+           |              |                                |
+      [Pioneer]    [arm_vel_integrator]  (TODO: fase 2)    |
+                          |                                |
+                   /b166er/arm_pos_cmd ──────────────────► [movemaster]
+
+  Modos
+  ─────
+    sim      : RViz + joint_state_publisher_gui (sem hardware real)
+    hardware : drivers reais (Pioneer + T265 + RV-M2)
+  ═══════════════════════════════════════════════════════════════════════
+  -->
+
+  <!-- ── Argumentos globais ──────────────────────────────────────── -->
+  <arg name="mode"          default="sim"
+       doc="Modo de operação: sim | hardware"/>
+  <arg name="rviz"          default="true"
+       doc="Abrir RViz de monitoramento"/>
+  <arg name="rate"          default="20"
+       doc="Taxa de controle do stack WB (Hz)"/>
+  <arg name="rviz_config"
+       default="$(find b166er_robot)/config/b166er.rviz"/>
+
+  <!-- ── Robot description ───────────────────────────────────────── -->
+  <param name="use_sim_time" value="false"/>
+  <param name="robot_description"
+         command="$(find xacro)/xacro
+                  $(find b166er_robot)/urdf/b166er.urdf.xacro"/>
+
+  <node name="robot_state_publisher"
+        pkg="robot_state_publisher"
+        type="robot_state_publisher"
+        output="screen"/>
+
+  <!-- ── Modo SIMULAÇÃO ──────────────────────────────────────────── -->
+  <group if="$(eval arg('mode') == 'sim')">
+
+    <!-- GUI para mover as juntas manualmente (desenvolvimento) -->
+    <node name="joint_state_publisher_gui"
+          pkg="joint_state_publisher_gui"
+          type="joint_state_publisher_gui"/>
+
+    <!-- RViz de monitoramento -->
+    <node if="$(arg rviz)"
+          name="rviz" pkg="rviz" type="rviz"
+          args="-d $(arg rviz_config)" output="screen"/>
+
+  </group>
+
+  <!-- ── Modo HARDWARE ───────────────────────────────────────────── -->
+  <group if="$(eval arg('mode') == 'hardware')">
+
+    <!-- Pioneer 3-AT -->
+    <include
+      file="$(find b166er_robot)/launch/hardware/pioneer_hardware.launch"/>
+
+    <!-- Intel RealSense T265 -->
+    <include
+      file="$(find b166er_robot)/launch/hardware/t265_hardware.launch"/>
+
+    <!-- Mitsubishi RV-M2 (rosserial + Arduino) -->
+    <include
+      file="$(find b166er_robot)/launch/hardware/movemaster_hardware.launch"/>
+
+    <!-- IMU Sparton AHRS-8 -->
+    <include
+      file="$(find b166er_robot)/launch/hardware/imu_hardware.launch"/>
+
+    <!-- RViz opcional em modo hardware -->
+    <node if="$(arg rviz)"
+          name="rviz" pkg="rviz" type="rviz"
+          args="-d $(arg rviz_config)" output="screen"/>
+
+  </group>
+
+  <!-- ── Stack de controle whole-body (sim + hardware) ───────────── -->
+
+  <!-- 1 · State estimator: funde T265 + Pioneer → q_arm (sem encoders) -->
+  <node name="state_estimator"
+        pkg="b166er_whole_body_control"
+        type="state_estimator.py"
+        output="screen">
+    <param name="t265_odom_topic"    value="/t265/odom/sample"/>
+    <param name="pioneer_odom_topic" value="/pioneer/pose"/>
+    <param name="world_frame"        value="odom"/>
+    <param name="rate"               value="$(arg rate)"/>
+  </node>
+
+  <!-- 2 · Controlador Fuzzy whole-body: Pioneer + RV-M2 como 8-DOF único -->
+  <node name="fuzzy_wb_controller"
+        pkg="b166er_whole_body_control"
+        type="fuzzy_wb_controller.py"
+        output="screen">
+    <param name="rate"             value="$(arg rate)"/>
+    <param name="nonholonomic"     value="true"/>
+    <param name="null_space_gain"  value="0.3"/>
+    <param name="tol_pos"          value="0.005"/>   <!-- 5 mm -->
+    <param name="tol_orient"       value="0.02"/>    <!-- ~1.1° -->
+  </node>
+
+  <!--
+  3 · arm_vel_integrator (TODO Fase 2):
+      Integra /b166er/arm_vel_cmd (rad/s) → /b166er/arm_pos_cmd
+      para interface com movemaster_control via rosserial.
+
+  <node name="arm_vel_integrator"
+        pkg="b166er_whole_body_control"
+        type="arm_vel_integrator.py"
+        output="screen">
+    <param name="rate" value="$(arg rate)"/>
+  </node>
+  -->
+
+</launch>

--- a/src/b166er_whole_body_control/launch/state_estimator.launch
+++ b/src/b166er_whole_body_control/launch/state_estimator.launch
@@ -1,0 +1,20 @@
+<launch>
+  <!-- state_estimator: funde T265 + odometria do Pioneer para estimar
+       o estado completo do b166er (q_base + q_arm) sem encoders. -->
+
+  <node name="state_estimator" pkg="b166er_whole_body_control"
+        type="state_estimator.py" output="screen">
+
+    <!-- Tópico de odometria da T265 (Intel RealSense) -->
+    <param name="t265_odom_topic"    value="/camera/odom/sample"/>
+
+    <!-- Tópico de odometria do Pioneer (RosAria) -->
+    <param name="pioneer_odom_topic" value="/RosAria/pose"/>
+
+    <!-- Frame de referência global -->
+    <param name="world_frame"        value="odom"/>
+
+    <!-- Taxa de publicação do RobotState (Hz) -->
+    <param name="rate"               value="20.0"/>
+  </node>
+</launch>

--- a/src/b166er_whole_body_control/msg/RobotState.msg
+++ b/src/b166er_whole_body_control/msg/RobotState.msg
@@ -1,0 +1,20 @@
+std_msgs/Header header
+
+# Base state — Pioneer odometry in world/odom frame
+nav_msgs/Odometry base_odom
+
+# EE state — T265 pose in world/odom frame
+geometry_msgs/PoseStamped ee_pose
+
+# Arm joint state estimate [J1..J5], radians — from IK(T265, base_odom)
+float64[] q_arm
+float64[] dq_arm
+
+# IK quality
+bool     ik_converged
+float64  ik_residual_pos     # metres
+float64  ik_residual_orient  # radians
+
+# Sensor health
+bool t265_valid
+bool base_odom_valid

--- a/src/b166er_whole_body_control/nodes/fuzzy_wb_controller.py
+++ b/src/b166er_whole_body_control/nodes/fuzzy_wb_controller.py
@@ -1,0 +1,285 @@
+#!/usr/bin/env python3
+"""
+fuzzy_wb_controller — controlador whole-body com ganho Fuzzy adaptativo.
+
+Substitui o ganho fixo K do whole_body_planner por um schedulador Mamdani
+que ajusta (k_pos, k_orient, lambda_dls) em função do erro e sua variação.
+
+Lei de controle:
+  q̇_wb = J_wb†(λ) · K_fuzzy · err_EE  +  (I − J_wb† J_wb) · q̇₀
+
+  K_fuzzy = diag(k_pos, k_pos, k_pos, k_orient, k_orient, k_orient)
+  λ       = lambda_dls adaptativo
+
+Tópicos
+-------
+  Subscreve:
+    /b166er/robot_state   (RobotState)   — estado completo
+    /b166er/ee_target     (PoseStamped)  — pose alvo do EE
+  Publica:
+    /cmd_vel              (Twist)        — base Pioneer
+    /b166er/arm_vel_cmd   (JointState)  — velocidade das juntas
+    /b166er/fuzzy_gains   (Float64MultiArray) — [k_pos, k_orient, lambda]
+    /b166er/wb_jacobian   (Float64MultiArray) — J_wb para diagnóstico
+"""
+
+import rospy
+import numpy as np
+from geometry_msgs.msg import PoseStamped, Twist
+from sensor_msgs.msg import JointState
+from std_msgs.msg import Float64MultiArray, MultiArrayDimension
+from tf.transformations import quaternion_matrix
+
+from b166er_whole_body_control.msg import RobotState
+from b166er_whole_body_control.kinematics import (
+    JOINT_NAMES, JOINT_LOWER, JOINT_UPPER,
+    whole_body_jacobian,
+    dls_pseudoinverse, null_space_projector,
+    joint_limit_gradient,
+    pose_error,
+)
+from b166er_whole_body_control.fuzzy_gain import FuzzyGain
+
+
+# ---------------------------------------------------------------------------
+# Saturação de velocidade
+# ---------------------------------------------------------------------------
+MAX_BASE_LIN = 0.3    # m/s
+MAX_BASE_ANG = 0.5    # rad/s
+MAX_ARM_VEL  = 0.8    # rad/s por junta
+K_NULL       = 0.3    # ganho do objetivo secundário (espaço nulo)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _odom_to_matrix(odom):
+    p = odom.pose.pose.position
+    o = odom.pose.pose.orientation
+    T = quaternion_matrix([o.x, o.y, o.z, o.w])
+    T[:3, 3] = [p.x, p.y, p.z]
+    return T
+
+
+def _pose_stamped_to_matrix(ps):
+    p = ps.pose.position
+    o = ps.pose.orientation
+    T = quaternion_matrix([o.x, o.y, o.z, o.w])
+    T[:3, 3] = [p.x, p.y, p.z]
+    return T
+
+
+def _saturate_base(v_lin, v_ang):
+    v_lin = float(np.clip(v_lin, -MAX_BASE_LIN, MAX_BASE_LIN))
+    v_ang = float(np.clip(v_ang, -MAX_BASE_ANG, MAX_BASE_ANG))
+    return v_lin, v_ang
+
+
+# ---------------------------------------------------------------------------
+# Nó principal
+# ---------------------------------------------------------------------------
+
+class FuzzyWBController:
+
+    def __init__(self):
+        rospy.init_node('fuzzy_wb_controller')
+
+        self._rate_hz = rospy.get_param('~rate',          20.0)
+        self._nonholo = rospy.get_param('~nonholonomic',  True)
+        self._ns_gain = rospy.get_param('~null_space_gain', K_NULL)
+
+        # Tolerâncias de parada
+        self._tol_pos    = rospy.get_param('~tol_pos',    0.005)   # m
+        self._tol_orient = rospy.get_param('~tol_orient', 0.02)    # rad
+
+        # Estado
+        self._robot_state = None
+        self._target      = None
+        self._enabled     = False
+
+        # Erro anterior (para derivada)
+        self._err_prev  = None
+        self._t_prev    = None
+        self._delta_err = 0.0
+
+        # Motor Fuzzy
+        self._fuzzy = FuzzyGain()
+
+        # Publicadores
+        self._pub_cmdvel  = rospy.Publisher('/cmd_vel',
+                                            Twist, queue_size=1)
+        self._pub_armvel  = rospy.Publisher('/b166er/arm_vel_cmd',
+                                            JointState, queue_size=1)
+        self._pub_gains   = rospy.Publisher('/b166er/fuzzy_gains',
+                                            Float64MultiArray, queue_size=1)
+        self._pub_jacobian = rospy.Publisher('/b166er/wb_jacobian',
+                                             Float64MultiArray, queue_size=1)
+
+        # Subscritores
+        rospy.Subscriber('/b166er/robot_state', RobotState,   self._cb_state)
+        rospy.Subscriber('/b166er/ee_target',   PoseStamped,  self._cb_target)
+
+        rospy.loginfo('[fuzzy_wb_controller] pronto — aguardando /b166er/ee_target')
+
+    # ------------------------------------------------------------------
+    def _cb_state(self, msg):
+        self._robot_state = msg
+
+    def _cb_target(self, msg):
+        self._target   = _pose_stamped_to_matrix(msg)
+        self._enabled  = True
+        self._err_prev = None   # reset derivada ao mudar alvo
+        rospy.loginfo('[fuzzy_wb_ctrl] novo alvo: pos=(%.3f, %.3f, %.3f)',
+                      msg.pose.position.x,
+                      msg.pose.position.y,
+                      msg.pose.position.z)
+
+    # ------------------------------------------------------------------
+    def _update_delta_err(self, err_total_norm, now):
+        """Estima d(||err||)/dt via diferença de primeira ordem."""
+        if self._err_prev is None or self._t_prev is None:
+            self._delta_err = 0.0
+        else:
+            dt = (now - self._t_prev).to_sec()
+            if dt > 1e-6:
+                self._delta_err = (err_total_norm - self._err_prev) / dt
+        self._err_prev = err_total_norm
+        self._t_prev   = now
+
+    def _get_ee_matrix(self, state):
+        """PoseStamped do EE → 4×4."""
+        p = state.ee_pose.pose.position
+        o = state.ee_pose.pose.orientation
+        T = quaternion_matrix([o.x, o.y, o.z, o.w])
+        T[:3, 3] = [p.x, p.y, p.z]
+        return T
+
+    def _project_nonholo(self, q_dot_base, theta):
+        """Projeta ẋ, ẏ na direção de heading do Pioneer."""
+        v_fwd = np.cos(theta) * q_dot_base[0] + np.sin(theta) * q_dot_base[1]
+        omega  = q_dot_base[2]
+        return v_fwd, omega
+
+    # ------------------------------------------------------------------
+    def _publish_cmd_vel(self, q_dot_base, theta):
+        msg = Twist()
+        if self._nonholo:
+            v, w = self._project_nonholo(q_dot_base, theta)
+            v, w = _saturate_base(v, w)
+            msg.linear.x  = v
+            msg.angular.z = w
+        else:
+            msg.linear.x  = float(np.clip(q_dot_base[0], -MAX_BASE_LIN, MAX_BASE_LIN))
+            msg.linear.y  = float(np.clip(q_dot_base[1], -MAX_BASE_LIN, MAX_BASE_LIN))
+            msg.angular.z = float(np.clip(q_dot_base[2], -MAX_BASE_ANG, MAX_BASE_ANG))
+        self._pub_cmdvel.publish(msg)
+
+    def _publish_arm_vel(self, q_dot_arm, stamp):
+        msg          = JointState()
+        msg.header.stamp = stamp
+        msg.name     = JOINT_NAMES
+        msg.velocity = np.clip(q_dot_arm, -MAX_ARM_VEL, MAX_ARM_VEL).tolist()
+        self._pub_armvel.publish(msg)
+
+    def _publish_gains(self, k_pos, k_orient, lam):
+        msg      = Float64MultiArray()
+        msg.data = [k_pos, k_orient, lam]
+        self._pub_gains.publish(msg)
+
+    def _publish_jacobian(self, J):
+        msg = Float64MultiArray()
+        d0  = MultiArrayDimension(label='rows', size=J.shape[0],
+                                  stride=J.shape[0] * J.shape[1])
+        d1  = MultiArrayDimension(label='cols', size=J.shape[1],
+                                  stride=J.shape[1])
+        msg.layout.dim = [d0, d1]
+        msg.data       = J.flatten().tolist()
+        self._pub_jacobian.publish(msg)
+
+    # ------------------------------------------------------------------
+    def spin(self):
+        rate = rospy.Rate(self._rate_hz)
+
+        while not rospy.is_shutdown():
+            now = rospy.Time.now()
+
+            if not self._enabled or self._robot_state is None:
+                self._pub_cmdvel.publish(Twist())
+                rate.sleep()
+                continue
+
+            state = self._robot_state
+
+            # ---- 1. Erro de pose do EE --------------------------------
+            T_cur    = self._get_ee_matrix(state)
+            err_EE   = pose_error(T_cur, self._target)     # (6,)
+
+            err_pos_norm    = float(np.linalg.norm(err_EE[:3]))
+            err_orient_norm = float(np.linalg.norm(err_EE[3:]))
+            err_total_norm  = err_pos_norm + 0.5 * err_orient_norm
+
+            self._update_delta_err(err_total_norm, now)
+
+            # Critério de parada
+            if err_pos_norm < self._tol_pos and err_orient_norm < self._tol_orient:
+                rospy.loginfo_throttle(2.0,
+                    '[fuzzy_wb_ctrl] alvo alcançado — pos=%.4fm ori=%.4frad',
+                    err_pos_norm, err_orient_norm)
+                self._pub_cmdvel.publish(Twist())
+                rate.sleep()
+                continue
+
+            # ---- 2. Ganho Fuzzy ----------------------------------------
+            k_pos, k_orient, lam = self._fuzzy.compute(
+                err_pos_norm, err_orient_norm, self._delta_err)
+
+            # Vetor de velocidade cartesiana desejada
+            xdot_d = np.concatenate([
+                k_pos    * err_EE[:3],
+                k_orient * err_EE[3:],
+            ])
+
+            # ---- 3. Jacobiana whole-body e DLS --------------------------
+            T_world_base = _odom_to_matrix(state.base_odom)
+            q_arm        = np.array(state.q_arm)
+
+            J_wb  = whole_body_jacobian(q_arm, T_world_base)
+            J_pin = dls_pseudoinverse(J_wb, lam)
+            N     = null_space_projector(J_wb, J_pin)
+
+            # ---- 4. Tarefa principal + espaço nulo ----------------------
+            q_dot_task = J_pin @ xdot_d
+
+            q_dot_null = N @ np.concatenate([
+                np.zeros(3),
+                self._ns_gain * joint_limit_gradient(q_arm),
+            ])
+
+            q_dot_wb = q_dot_task + q_dot_null   # (8,)
+
+            # ---- 5. Publica comandos ------------------------------------
+            theta = float(np.arctan2(T_world_base[1, 0], T_world_base[0, 0]))
+
+            self._publish_cmd_vel(q_dot_wb[:3], theta)
+            self._publish_arm_vel(q_dot_wb[3:], now)
+            self._publish_gains(k_pos, k_orient, lam)
+            self._publish_jacobian(J_wb)
+
+            rospy.loginfo_throttle(1.0,
+                '[fuzzy_wb] err_p=%.4fm err_o=%.4frad δerr=%.4f | '
+                'k=[%.2f %.2f] λ=%.3f | '
+                'base=[%.2f %.2f] arm=[%.2f %.2f %.2f %.2f %.2f]',
+                err_pos_norm, err_orient_norm, self._delta_err,
+                k_pos, k_orient, lam,
+                *q_dot_wb[:2].round(3), *q_dot_wb[3:].round(3))
+
+            rate.sleep()
+
+
+# ---------------------------------------------------------------------------
+if __name__ == '__main__':
+    try:
+        FuzzyWBController().spin()
+    except rospy.ROSInterruptException:
+        pass

--- a/src/b166er_whole_body_control/nodes/state_estimator.py
+++ b/src/b166er_whole_body_control/nodes/state_estimator.py
@@ -1,0 +1,341 @@
+#!/usr/bin/env python3
+"""
+state_estimator — whole-body state for b166er without joint encoders.
+
+Fuses:
+  • T265 odometry  → EE pose in world frame
+  • Pioneer odom   → base pose (x, y, θ) in world frame
+
+Estimates arm joint angles via numerical IK so the whole-body controller
+can reason about the full 8-DOF chain (3 base + 5 arm) as a single entity.
+
+Kinematic chain (Base frame → t265_link):
+  Base → J1(RotZ) → L1 → J2(RotZ) → L2 → J3(RotZ) → L3
+       → J4(RotZ) → L4 → J5(RotZ) → L5 → CameraSupport → t265_link
+"""
+
+import rospy
+import numpy as np
+from nav_msgs.msg import Odometry
+from geometry_msgs.msg import PoseStamped, TransformStamped
+from sensor_msgs.msg import JointState
+import tf2_ros
+import tf2_geometry_msgs
+from tf.transformations import (quaternion_matrix, quaternion_from_matrix,
+                                 euler_from_matrix)
+
+from b166er_whole_body_control.msg import RobotState
+
+
+# ---------------------------------------------------------------------------
+# RV-M2 joint limits [lower, upper] in radians (from URDF / manual)
+# ---------------------------------------------------------------------------
+JOINT_NAMES  = ['J1', 'J2', 'J3', 'J4', 'J5']
+JOINT_LOWER  = np.array([-2.61799, -1.13446, -1.04720, -1.91986, -3.14159])
+JOINT_UPPER  = np.array([ 2.61799,  1.13446,  1.04720,  1.91986,  3.14159])
+
+# IK tuning
+IK_MAX_ITER   = 150
+IK_TOL_POS    = 1e-4   # metres
+IK_TOL_ORIENT = 1e-3   # radians
+IK_LAMBDA     = 0.05   # DLS damping
+IK_DQ_FINITE  = 1e-6   # Jacobian step size
+
+
+# ---------------------------------------------------------------------------
+# Pure-numpy homogeneous transform helpers
+# ---------------------------------------------------------------------------
+
+def _rotx(a):
+    c, s = np.cos(a), np.sin(a)
+    return np.array([[1,0,0,0],[0,c,-s,0],[0,s,c,0],[0,0,0,1]], dtype=float)
+
+def _roty(a):
+    c, s = np.cos(a), np.sin(a)
+    return np.array([[c,0,s,0],[0,1,0,0],[-s,0,c,0],[0,0,0,1]], dtype=float)
+
+def _rotz(a):
+    c, s = np.cos(a), np.sin(a)
+    return np.array([[c,-s,0,0],[s,c,0,0],[0,0,1,0],[0,0,0,1]], dtype=float)
+
+def _trans(x, y, z):
+    T = np.eye(4)
+    T[:3, 3] = [x, y, z]
+    return T
+
+def _tf(xyz, rpy):
+    """Combined translation + RPY rotation (extrinsic: Rz*Ry*Rx)."""
+    T = np.eye(4)
+    T[:3, :3] = (  _rotz(rpy[2]) @ _roty(rpy[1]) @ _rotx(rpy[0])  )[:3, :3]
+    T[:3,  3] = xyz
+    return T
+
+
+# Fixed transforms (from URDF)
+#   base_link → top_plate : xyz=(0.003, 0, 0.274)
+#   top_plate → Base (arm): xyz=(0,     0, 0.02)
+#   combined:
+T_BASE_LINK_TO_ARM_BASE = _tf([0.003, 0, 0.294], [0, 0, 0])
+
+# Precomputed constant suffix: L5 → t265_link
+# JCam: xyz=(0,0,-0.08), fixed
+# t265_mount: xyz=(0,0.075,-0.07), rpy=(0, 2.1, 1.57)
+_T_L5_T265 = _trans(0, 0, -0.08) @ _tf([0, 0.075, -0.07], [0, 2.1, 1.57])
+
+
+def fk_arm(q):
+    """
+    Forward kinematics: Base → t265_link.
+
+    Parameters
+    ----------
+    q : array-like, shape (5,)
+        Joint angles [q1, q2, q3, q4, q5] in radians.
+
+    Returns
+    -------
+    T : ndarray, shape (4, 4)
+        Homogeneous transform from arm Base frame to t265_link.
+    """
+    q1, q2, q3, q4, q5 = q
+
+    T = (
+        _trans(0, 0, 0.4)    @ _rotz(q1)              # J1
+        @ _trans(0.12, 0, 0) @ _rotx(1.5708) @ _rotz(q2)  # J2
+        @ _trans(0.25, 0, 0) @ _rotz(q3)               # J3
+        @ _trans(0.2,  0, 0) @ _rotz(q4)               # J4
+        @ _roty(-1.5708)     @ _rotz(q5)               # J5
+        @ _T_L5_T265                                    # fixed suffix
+    )
+    return T
+
+
+def _T_to_6vec(T):
+    """4×4 transform → 6-vector [x, y, z, wx, wy, wz] for Jacobian computation.
+    Orientation uses the skew-symmetric extraction (≈ axis×sin(angle))."""
+    pos = T[:3, 3]
+    R   = T[:3, :3]
+    dw  = np.array([R[2,1]-R[1,2], R[0,2]-R[2,0], R[1,0]-R[0,1]]) * 0.5
+    return np.concatenate([pos, dw])
+
+
+def _pose_error(T_current, T_target):
+    """
+    6-vector error [dp (3), dω (3)] for DLS IK.
+    dp  = position error.
+    dω  = axis-angle of orientation error R_err = R_target × R_current^T.
+    """
+    dp    = T_target[:3, 3] - T_current[:3, 3]
+    R_err = T_target[:3, :3] @ T_current[:3, :3].T
+    dω    = np.array([
+        R_err[2, 1] - R_err[1, 2],
+        R_err[0, 2] - R_err[2, 0],
+        R_err[1, 0] - R_err[0, 1],
+    ]) * 0.5
+    return np.concatenate([dp, dω])
+
+
+def ik_arm(T_target, q_init=None):
+    """
+    Numerical IK for the RV-M2 arm (Base → t265_link).
+
+    Uses damped least-squares (DLS) with a numerical Jacobian.
+
+    Parameters
+    ----------
+    T_target : ndarray (4, 4)
+        Desired Base → t265_link transform.
+    q_init : array-like (5,) or None
+        Initial joint angles. Defaults to zeros.
+
+    Returns
+    -------
+    q : ndarray (5,)
+        Estimated joint angles.
+    converged : bool
+    residual_pos : float    metres
+    residual_orient : float radians
+    """
+    q = np.zeros(5) if q_init is None else np.array(q_init, dtype=float)
+
+    for _ in range(IK_MAX_ITER):
+        T_cur = fk_arm(q)
+        err   = _pose_error(T_cur, T_target)
+
+        res_pos    = np.linalg.norm(err[:3])
+        res_orient = np.linalg.norm(err[3:])
+
+        if res_pos < IK_TOL_POS and res_orient < IK_TOL_ORIENT:
+            return q, True, res_pos, res_orient
+
+        # Numerical Jacobian of FK (6×5): J = d(pose)/d(q_i)
+        # Must use FK derivative, NOT error derivative (different sign).
+        J = np.zeros((6, 5))
+        for i in range(5):
+            dq_i      = np.zeros(5)
+            dq_i[i]   = IK_DQ_FINITE
+            J[:, i]   = (_T_to_6vec(fk_arm(q + dq_i))
+                         - _T_to_6vec(fk_arm(q - dq_i))) / (2 * IK_DQ_FINITE)
+
+        # DLS: dq = J^T (J J^T + λ²I)^{-1} err
+        JJT = J @ J.T
+        dq  = J.T @ np.linalg.solve(JJT + IK_LAMBDA**2 * np.eye(6), err)
+
+        q  = np.clip(q + dq, JOINT_LOWER, JOINT_UPPER)
+
+    T_cur = fk_arm(q)
+    err   = _pose_error(T_cur, T_target)
+    return q, False, np.linalg.norm(err[:3]), np.linalg.norm(err[3:])
+
+
+# ---------------------------------------------------------------------------
+# ROS node
+# ---------------------------------------------------------------------------
+
+class StateEstimator:
+
+    def __init__(self):
+        rospy.init_node('state_estimator')
+
+        # Parameters
+        self._t265_topic    = rospy.get_param('~t265_odom_topic',    '/camera/odom/sample')
+        self._pioneer_topic = rospy.get_param('~pioneer_odom_topic', '/RosAria/pose')
+        self._world_frame   = rospy.get_param('~world_frame',        'odom')
+        self._arm_base_frame = rospy.get_param('~arm_base_frame',    'Base')
+        self._pub_rate      = rospy.get_param('~rate', 20.0)
+
+        # State
+        self._base_odom  = None
+        self._t265_odom  = None
+        self._q_arm      = np.zeros(5)
+        self._dq_arm     = np.zeros(5)
+        self._q_arm_prev = np.zeros(5)
+        self._t_prev     = None
+
+        # TF
+        self._tf_buf      = tf2_ros.Buffer()
+        self._tf_listener = tf2_ros.TransformListener(self._tf_buf)
+        self._tf_broadcaster = tf2_ros.TransformBroadcaster()
+
+        # Publishers
+        self._pub_state = rospy.Publisher(
+            '/b166er/robot_state', RobotState, queue_size=5)
+        self._pub_joints = rospy.Publisher(
+            '/b166er/estimated_joint_states', JointState, queue_size=5)
+
+        # Subscribers
+        rospy.Subscriber(self._pioneer_topic, Odometry, self._cb_pioneer)
+        rospy.Subscriber(self._t265_topic,    Odometry, self._cb_t265)
+
+        rospy.loginfo('[state_estimator] ready')
+        rospy.loginfo('  pioneer: %s', self._pioneer_topic)
+        rospy.loginfo('  t265:    %s', self._t265_topic)
+
+    # ------------------------------------------------------------------
+    def _cb_pioneer(self, msg):
+        self._base_odom = msg
+
+    def _cb_t265(self, msg):
+        self._t265_odom = msg
+
+    # ------------------------------------------------------------------
+    def _odom_to_matrix(self, odom):
+        """nav_msgs/Odometry → 4×4 homogeneous transform."""
+        p = odom.pose.pose.position
+        o = odom.pose.pose.orientation
+        T = quaternion_matrix([o.x, o.y, o.z, o.w])
+        T[:3, 3] = [p.x, p.y, p.z]
+        return T
+
+    def _compute_T_target(self):
+        """
+        Compute T_ArmBase_t265 from Pioneer odom + T265 odom.
+
+        T_ArmBase_t265 = T_world_ArmBase^{-1} × T_world_t265
+
+        T_world_ArmBase = T_world_baselink × T_BASELINK_ARM_BASE
+        T_world_t265    = from T265 odom (already in world/odom frame)
+        """
+        T_world_base = self._odom_to_matrix(self._base_odom)
+        T_world_t265 = self._odom_to_matrix(self._t265_odom)
+
+        T_world_arm_base = T_world_base @ T_BASE_LINK_TO_ARM_BASE
+        T_arm_base_t265  = np.linalg.inv(T_world_arm_base) @ T_world_t265
+        return T_arm_base_t265
+
+    # ------------------------------------------------------------------
+    def _publish_joint_states(self, q, stamp):
+        msg = JointState()
+        msg.header.stamp = stamp
+        msg.name     = JOINT_NAMES
+        msg.position = q.tolist()
+        msg.velocity = self._dq_arm.tolist()
+        self._pub_joints.publish(msg)
+
+    def _publish_state(self, T_target, q, converged, res_p, res_o, stamp):
+        msg = RobotState()
+        msg.header.stamp    = stamp
+        msg.header.frame_id = self._world_frame
+
+        msg.base_odom      = self._base_odom
+        msg.base_odom_valid = True
+
+        # EE pose in world frame (from T265 directly)
+        ee = PoseStamped()
+        ee.header.stamp    = stamp
+        ee.header.frame_id = self._world_frame
+        p = self._t265_odom.pose.pose.position
+        o = self._t265_odom.pose.pose.orientation
+        ee.pose.position    = p
+        ee.pose.orientation = o
+        msg.ee_pose      = ee
+        msg.t265_valid   = True
+
+        msg.q_arm            = q.tolist()
+        msg.dq_arm           = self._dq_arm.tolist()
+        msg.ik_converged     = converged
+        msg.ik_residual_pos  = float(res_p)
+        msg.ik_residual_orient = float(res_o)
+
+        self._pub_state.publish(msg)
+
+    # ------------------------------------------------------------------
+    def spin(self):
+        rate = rospy.Rate(self._pub_rate)
+
+        while not rospy.is_shutdown():
+            now = rospy.Time.now()
+
+            if self._base_odom is None or self._t265_odom is None:
+                rate.sleep()
+                continue
+
+            # IK
+            T_target = self._compute_T_target()
+            q, conv, res_p, res_o = ik_arm(T_target, q_init=self._q_arm)
+
+            # Joint velocity estimate
+            dt = (now - self._t_prev).to_sec() if self._t_prev else None
+            if dt and dt > 0:
+                self._dq_arm = (q - self._q_arm_prev) / dt
+            self._q_arm_prev = q.copy()
+            self._q_arm      = q
+            self._t_prev     = now
+
+            self._publish_state(T_target, q, conv, res_p, res_o, now)
+            self._publish_joint_states(q, now)
+
+            if not conv:
+                rospy.logwarn_throttle(5.0,
+                    '[state_estimator] IK não convergiu — pos=%.4fm orient=%.4frad',
+                    res_p, res_o)
+
+            rate.sleep()
+
+
+# ---------------------------------------------------------------------------
+if __name__ == '__main__':
+    try:
+        StateEstimator().spin()
+    except rospy.ROSInterruptException:
+        pass

--- a/src/b166er_whole_body_control/nodes/state_estimator.py
+++ b/src/b166er_whole_body_control/nodes/state_estimator.py
@@ -8,262 +8,72 @@ Fuses:
 
 Estimates arm joint angles via numerical IK so the whole-body controller
 can reason about the full 8-DOF chain (3 base + 5 arm) as a single entity.
-
-Kinematic chain (Base frame → t265_link):
-  Base → J1(RotZ) → L1 → J2(RotZ) → L2 → J3(RotZ) → L3
-       → J4(RotZ) → L4 → J5(RotZ) → L5 → CameraSupport → t265_link
 """
 
 import rospy
 import numpy as np
 from nav_msgs.msg import Odometry
-from geometry_msgs.msg import PoseStamped, TransformStamped
+from geometry_msgs.msg import PoseStamped
 from sensor_msgs.msg import JointState
-import tf2_ros
-import tf2_geometry_msgs
-from tf.transformations import (quaternion_matrix, quaternion_from_matrix,
-                                 euler_from_matrix)
+from tf.transformations import quaternion_matrix
 
 from b166er_whole_body_control.msg import RobotState
+from b166er_whole_body_control.kinematics import (
+    JOINT_NAMES, T_BASELINK_ARM,
+    ik_arm,
+)
 
 
-# ---------------------------------------------------------------------------
-# RV-M2 joint limits [lower, upper] in radians (from URDF / manual)
-# ---------------------------------------------------------------------------
-JOINT_NAMES  = ['J1', 'J2', 'J3', 'J4', 'J5']
-JOINT_LOWER  = np.array([-2.61799, -1.13446, -1.04720, -1.91986, -3.14159])
-JOINT_UPPER  = np.array([ 2.61799,  1.13446,  1.04720,  1.91986,  3.14159])
-
-# IK tuning
-IK_MAX_ITER   = 150
-IK_TOL_POS    = 1e-4   # metres
-IK_TOL_ORIENT = 1e-3   # radians
-IK_LAMBDA     = 0.05   # DLS damping
-IK_DQ_FINITE  = 1e-6   # Jacobian step size
-
-
-# ---------------------------------------------------------------------------
-# Pure-numpy homogeneous transform helpers
-# ---------------------------------------------------------------------------
-
-def _rotx(a):
-    c, s = np.cos(a), np.sin(a)
-    return np.array([[1,0,0,0],[0,c,-s,0],[0,s,c,0],[0,0,0,1]], dtype=float)
-
-def _roty(a):
-    c, s = np.cos(a), np.sin(a)
-    return np.array([[c,0,s,0],[0,1,0,0],[-s,0,c,0],[0,0,0,1]], dtype=float)
-
-def _rotz(a):
-    c, s = np.cos(a), np.sin(a)
-    return np.array([[c,-s,0,0],[s,c,0,0],[0,0,1,0],[0,0,0,1]], dtype=float)
-
-def _trans(x, y, z):
-    T = np.eye(4)
-    T[:3, 3] = [x, y, z]
+def _odom_to_matrix(odom):
+    """nav_msgs/Odometry → 4×4 homogeneous transform."""
+    p = odom.pose.pose.position
+    o = odom.pose.pose.orientation
+    T = quaternion_matrix([o.x, o.y, o.z, o.w])
+    T[:3, 3] = [p.x, p.y, p.z]
     return T
 
-def _tf(xyz, rpy):
-    """Combined translation + RPY rotation (extrinsic: Rz*Ry*Rx)."""
-    T = np.eye(4)
-    T[:3, :3] = (  _rotz(rpy[2]) @ _roty(rpy[1]) @ _rotx(rpy[0])  )[:3, :3]
-    T[:3,  3] = xyz
-    return T
-
-
-# Fixed transforms (from URDF)
-#   base_link → top_plate : xyz=(0.003, 0, 0.274)
-#   top_plate → Base (arm): xyz=(0,     0, 0.02)
-#   combined:
-T_BASE_LINK_TO_ARM_BASE = _tf([0.003, 0, 0.294], [0, 0, 0])
-
-# Precomputed constant suffix: L5 → t265_link
-# JCam: xyz=(0,0,-0.08), fixed
-# t265_mount: xyz=(0,0.075,-0.07), rpy=(0, 2.1, 1.57)
-_T_L5_T265 = _trans(0, 0, -0.08) @ _tf([0, 0.075, -0.07], [0, 2.1, 1.57])
-
-
-def fk_arm(q):
-    """
-    Forward kinematics: Base → t265_link.
-
-    Parameters
-    ----------
-    q : array-like, shape (5,)
-        Joint angles [q1, q2, q3, q4, q5] in radians.
-
-    Returns
-    -------
-    T : ndarray, shape (4, 4)
-        Homogeneous transform from arm Base frame to t265_link.
-    """
-    q1, q2, q3, q4, q5 = q
-
-    T = (
-        _trans(0, 0, 0.4)    @ _rotz(q1)              # J1
-        @ _trans(0.12, 0, 0) @ _rotx(1.5708) @ _rotz(q2)  # J2
-        @ _trans(0.25, 0, 0) @ _rotz(q3)               # J3
-        @ _trans(0.2,  0, 0) @ _rotz(q4)               # J4
-        @ _roty(-1.5708)     @ _rotz(q5)               # J5
-        @ _T_L5_T265                                    # fixed suffix
-    )
-    return T
-
-
-def _T_to_6vec(T):
-    """4×4 transform → 6-vector [x, y, z, wx, wy, wz] for Jacobian computation.
-    Orientation uses the skew-symmetric extraction (≈ axis×sin(angle))."""
-    pos = T[:3, 3]
-    R   = T[:3, :3]
-    dw  = np.array([R[2,1]-R[1,2], R[0,2]-R[2,0], R[1,0]-R[0,1]]) * 0.5
-    return np.concatenate([pos, dw])
-
-
-def _pose_error(T_current, T_target):
-    """
-    6-vector error [dp (3), dω (3)] for DLS IK.
-    dp  = position error.
-    dω  = axis-angle of orientation error R_err = R_target × R_current^T.
-    """
-    dp    = T_target[:3, 3] - T_current[:3, 3]
-    R_err = T_target[:3, :3] @ T_current[:3, :3].T
-    dω    = np.array([
-        R_err[2, 1] - R_err[1, 2],
-        R_err[0, 2] - R_err[2, 0],
-        R_err[1, 0] - R_err[0, 1],
-    ]) * 0.5
-    return np.concatenate([dp, dω])
-
-
-def ik_arm(T_target, q_init=None):
-    """
-    Numerical IK for the RV-M2 arm (Base → t265_link).
-
-    Uses damped least-squares (DLS) with a numerical Jacobian.
-
-    Parameters
-    ----------
-    T_target : ndarray (4, 4)
-        Desired Base → t265_link transform.
-    q_init : array-like (5,) or None
-        Initial joint angles. Defaults to zeros.
-
-    Returns
-    -------
-    q : ndarray (5,)
-        Estimated joint angles.
-    converged : bool
-    residual_pos : float    metres
-    residual_orient : float radians
-    """
-    q = np.zeros(5) if q_init is None else np.array(q_init, dtype=float)
-
-    for _ in range(IK_MAX_ITER):
-        T_cur = fk_arm(q)
-        err   = _pose_error(T_cur, T_target)
-
-        res_pos    = np.linalg.norm(err[:3])
-        res_orient = np.linalg.norm(err[3:])
-
-        if res_pos < IK_TOL_POS and res_orient < IK_TOL_ORIENT:
-            return q, True, res_pos, res_orient
-
-        # Numerical Jacobian of FK (6×5): J = d(pose)/d(q_i)
-        # Must use FK derivative, NOT error derivative (different sign).
-        J = np.zeros((6, 5))
-        for i in range(5):
-            dq_i      = np.zeros(5)
-            dq_i[i]   = IK_DQ_FINITE
-            J[:, i]   = (_T_to_6vec(fk_arm(q + dq_i))
-                         - _T_to_6vec(fk_arm(q - dq_i))) / (2 * IK_DQ_FINITE)
-
-        # DLS: dq = J^T (J J^T + λ²I)^{-1} err
-        JJT = J @ J.T
-        dq  = J.T @ np.linalg.solve(JJT + IK_LAMBDA**2 * np.eye(6), err)
-
-        q  = np.clip(q + dq, JOINT_LOWER, JOINT_UPPER)
-
-    T_cur = fk_arm(q)
-    err   = _pose_error(T_cur, T_target)
-    return q, False, np.linalg.norm(err[:3]), np.linalg.norm(err[3:])
-
-
-# ---------------------------------------------------------------------------
-# ROS node
-# ---------------------------------------------------------------------------
 
 class StateEstimator:
 
     def __init__(self):
         rospy.init_node('state_estimator')
 
-        # Parameters
         self._t265_topic    = rospy.get_param('~t265_odom_topic',    '/camera/odom/sample')
         self._pioneer_topic = rospy.get_param('~pioneer_odom_topic', '/RosAria/pose')
         self._world_frame   = rospy.get_param('~world_frame',        'odom')
-        self._arm_base_frame = rospy.get_param('~arm_base_frame',    'Base')
         self._pub_rate      = rospy.get_param('~rate', 20.0)
 
-        # State
         self._base_odom  = None
         self._t265_odom  = None
         self._q_arm      = np.zeros(5)
-        self._dq_arm     = np.zeros(5)
         self._q_arm_prev = np.zeros(5)
+        self._dq_arm     = np.zeros(5)
         self._t_prev     = None
 
-        # TF
-        self._tf_buf      = tf2_ros.Buffer()
-        self._tf_listener = tf2_ros.TransformListener(self._tf_buf)
-        self._tf_broadcaster = tf2_ros.TransformBroadcaster()
+        self._pub_state  = rospy.Publisher('/b166er/robot_state',
+                                           RobotState, queue_size=5)
+        self._pub_joints = rospy.Publisher('/b166er/estimated_joint_states',
+                                           JointState, queue_size=5)
 
-        # Publishers
-        self._pub_state = rospy.Publisher(
-            '/b166er/robot_state', RobotState, queue_size=5)
-        self._pub_joints = rospy.Publisher(
-            '/b166er/estimated_joint_states', JointState, queue_size=5)
-
-        # Subscribers
         rospy.Subscriber(self._pioneer_topic, Odometry, self._cb_pioneer)
         rospy.Subscriber(self._t265_topic,    Odometry, self._cb_t265)
 
-        rospy.loginfo('[state_estimator] ready')
+        rospy.loginfo('[state_estimator] pronto')
         rospy.loginfo('  pioneer: %s', self._pioneer_topic)
         rospy.loginfo('  t265:    %s', self._t265_topic)
 
-    # ------------------------------------------------------------------
-    def _cb_pioneer(self, msg):
-        self._base_odom = msg
-
-    def _cb_t265(self, msg):
-        self._t265_odom = msg
-
-    # ------------------------------------------------------------------
-    def _odom_to_matrix(self, odom):
-        """nav_msgs/Odometry → 4×4 homogeneous transform."""
-        p = odom.pose.pose.position
-        o = odom.pose.pose.orientation
-        T = quaternion_matrix([o.x, o.y, o.z, o.w])
-        T[:3, 3] = [p.x, p.y, p.z]
-        return T
+    def _cb_pioneer(self, msg): self._base_odom = msg
+    def _cb_t265(self, msg):    self._t265_odom = msg
 
     def _compute_T_target(self):
         """
-        Compute T_ArmBase_t265 from Pioneer odom + T265 odom.
-
-        T_ArmBase_t265 = T_world_ArmBase^{-1} × T_world_t265
-
-        T_world_ArmBase = T_world_baselink × T_BASELINK_ARM_BASE
-        T_world_t265    = from T265 odom (already in world/odom frame)
+        T_ArmBase_t265 = (T_world_base × T_BASELINK_ARM)^{-1} × T_world_t265
         """
-        T_world_base = self._odom_to_matrix(self._base_odom)
-        T_world_t265 = self._odom_to_matrix(self._t265_odom)
+        T_world_base     = _odom_to_matrix(self._base_odom)
+        T_world_t265     = _odom_to_matrix(self._t265_odom)
+        T_world_arm_base = T_world_base @ T_BASELINK_ARM
+        return np.linalg.inv(T_world_arm_base) @ T_world_t265
 
-        T_world_arm_base = T_world_base @ T_BASE_LINK_TO_ARM_BASE
-        T_arm_base_t265  = np.linalg.inv(T_world_arm_base) @ T_world_t265
-        return T_arm_base_t265
-
-    # ------------------------------------------------------------------
     def _publish_joint_states(self, q, stamp):
         msg = JointState()
         msg.header.stamp = stamp
@@ -272,34 +82,27 @@ class StateEstimator:
         msg.velocity = self._dq_arm.tolist()
         self._pub_joints.publish(msg)
 
-    def _publish_state(self, T_target, q, converged, res_p, res_o, stamp):
+    def _publish_state(self, q, converged, res_p, res_o, stamp):
         msg = RobotState()
         msg.header.stamp    = stamp
         msg.header.frame_id = self._world_frame
-
-        msg.base_odom      = self._base_odom
+        msg.base_odom       = self._base_odom
         msg.base_odom_valid = True
 
-        # EE pose in world frame (from T265 directly)
         ee = PoseStamped()
         ee.header.stamp    = stamp
         ee.header.frame_id = self._world_frame
-        p = self._t265_odom.pose.pose.position
-        o = self._t265_odom.pose.pose.orientation
-        ee.pose.position    = p
-        ee.pose.orientation = o
-        msg.ee_pose      = ee
-        msg.t265_valid   = True
+        ee.pose            = self._t265_odom.pose.pose
+        msg.ee_pose        = ee
+        msg.t265_valid     = True
 
-        msg.q_arm            = q.tolist()
-        msg.dq_arm           = self._dq_arm.tolist()
-        msg.ik_converged     = converged
-        msg.ik_residual_pos  = float(res_p)
+        msg.q_arm              = q.tolist()
+        msg.dq_arm             = self._dq_arm.tolist()
+        msg.ik_converged       = converged
+        msg.ik_residual_pos    = float(res_p)
         msg.ik_residual_orient = float(res_o)
-
         self._pub_state.publish(msg)
 
-    # ------------------------------------------------------------------
     def spin(self):
         rate = rospy.Rate(self._pub_rate)
 
@@ -310,11 +113,9 @@ class StateEstimator:
                 rate.sleep()
                 continue
 
-            # IK
             T_target = self._compute_T_target()
             q, conv, res_p, res_o = ik_arm(T_target, q_init=self._q_arm)
 
-            # Joint velocity estimate
             dt = (now - self._t_prev).to_sec() if self._t_prev else None
             if dt and dt > 0:
                 self._dq_arm = (q - self._q_arm_prev) / dt
@@ -322,18 +123,16 @@ class StateEstimator:
             self._q_arm      = q
             self._t_prev     = now
 
-            self._publish_state(T_target, q, conv, res_p, res_o, now)
+            self._publish_state(q, conv, res_p, res_o, now)
             self._publish_joint_states(q, now)
 
             if not conv:
                 rospy.logwarn_throttle(5.0,
                     '[state_estimator] IK não convergiu — pos=%.4fm orient=%.4frad',
                     res_p, res_o)
-
             rate.sleep()
 
 
-# ---------------------------------------------------------------------------
 if __name__ == '__main__':
     try:
         StateEstimator().spin()

--- a/src/b166er_whole_body_control/nodes/state_estimator.py
+++ b/src/b166er_whole_body_control/nodes/state_estimator.py
@@ -38,8 +38,8 @@ class StateEstimator:
     def __init__(self):
         rospy.init_node('state_estimator')
 
-        self._t265_topic    = rospy.get_param('~t265_odom_topic',    '/camera/odom/sample')
-        self._pioneer_topic = rospy.get_param('~pioneer_odom_topic', '/RosAria/pose')
+        self._t265_topic    = rospy.get_param('~t265_odom_topic',    '/t265/odom/sample')
+        self._pioneer_topic = rospy.get_param('~pioneer_odom_topic', '/pioneer/pose')
         self._world_frame   = rospy.get_param('~world_frame',        'odom')
         self._pub_rate      = rospy.get_param('~rate', 20.0)
 

--- a/src/b166er_whole_body_control/nodes/whole_body_planner.py
+++ b/src/b166er_whole_body_control/nodes/whole_body_planner.py
@@ -1,0 +1,282 @@
+#!/usr/bin/env python3
+"""
+whole_body_planner — controlador whole-body unificado do b166er.
+
+O sistema é tratado como uma única entidade de 8-DOF:
+  q_wb = [x_b, y_b, θ_b,  q1, q2, q3, q4, q5]
+          ←  base  →       ←— braço RV-M2 —→
+
+Path planning é global: Pioneer e RV-M2 se movem SIMULTANEAMENTE.
+
+Lei de controle (PBVS whole-body com DLS + espaço nulo):
+
+  q̇_wb = J_wb† · K · err_EE  +  (I − J_wb† J_wb) · q̇₀
+
+  onde:
+    J_wb    = Jacobiana whole-body 6×8 [J_base | J_arm]
+    K       = ganho (substituído pelo Fuzzy na próxima fase)
+    err_EE  = erro 6D entre EE atual (T265) e alvo
+    q̇₀     = objetivo secundário (evitar limites de junta)
+
+Tópicos
+-------
+  Subscreve:
+    /b166er/robot_state    (RobotState)    — estado completo do robô
+    /b166er/ee_target      (PoseStamped)   — pose alvo do EE no frame mundial
+  Publica:
+    /cmd_vel               (Twist)         — velocidade da base Pioneer
+    /b166er/arm_vel_cmd    (JointState)    — velocidade das juntas do braço
+    /b166er/wb_jacobian    (Float64MultiArray) — J_wb para debug/logging
+"""
+
+import rospy
+import numpy as np
+from geometry_msgs.msg import PoseStamped, Twist
+from sensor_msgs.msg import JointState
+from std_msgs.msg import Float64MultiArray, MultiArrayDimension
+from tf.transformations import quaternion_matrix
+
+from b166er_whole_body_control.msg import RobotState
+from b166er_whole_body_control.kinematics import (
+    JOINT_NAMES, JOINT_LOWER, JOINT_UPPER,
+    T_BASELINK_ARM,
+    fk_arm_joint_frames,
+    whole_body_jacobian,
+    dls_pseudoinverse, null_space_projector,
+    joint_limit_gradient,
+    pose_error,
+)
+
+# ---------------------------------------------------------------------------
+# Parâmetros de controle
+# ---------------------------------------------------------------------------
+
+# Ganho proporcional (será substituído pelo Fuzzy)
+K_POS    = 0.8   # m/s por metro de erro
+K_ORIENT = 0.6   # rad/s por rad de erro
+
+# Saturação de velocidade
+MAX_BASE_LIN  = 0.3    # m/s
+MAX_BASE_ANG  = 0.5    # rad/s
+MAX_ARM_VEL   = 0.8    # rad/s por junta
+
+# Ganho do objetivo secundário (evitar limites de junta)
+K_NULL   = 0.3
+
+# DLS — será substituído por λ adaptativo do Fuzzy
+DLS_LAMBDA = 0.05
+
+
+# ---------------------------------------------------------------------------
+# Helpers de conversão
+# ---------------------------------------------------------------------------
+
+def _odom_to_matrix(odom):
+    """nav_msgs/Odometry → 4×4."""
+    p = odom.pose.pose.position
+    o = odom.pose.pose.orientation
+    T = quaternion_matrix([o.x, o.y, o.z, o.w])
+    T[:3, 3] = [p.x, p.y, p.z]
+    return T
+
+
+def _pose_stamped_to_matrix(ps):
+    """geometry_msgs/PoseStamped → 4×4."""
+    p = ps.pose.position
+    o = ps.pose.orientation
+    T = quaternion_matrix([o.x, o.y, o.z, o.w])
+    T[:3, 3] = [p.x, p.y, p.z]
+    return T
+
+
+def _saturate(v, vmax):
+    """Escala o vetor se a norma exceder vmax."""
+    n = np.linalg.norm(v)
+    return v if n <= vmax else v * (vmax / n)
+
+
+# ---------------------------------------------------------------------------
+# Nó principal
+# ---------------------------------------------------------------------------
+
+class WholeBodyPlanner:
+
+    def __init__(self):
+        rospy.init_node('whole_body_planner')
+
+        # Parâmetros
+        self._rate_hz  = rospy.get_param('~rate', 20.0)
+        self._nonholo  = rospy.get_param('~nonholonomic', True)
+        self._ns_gain  = rospy.get_param('~null_space_gain', K_NULL)
+
+        # Estado
+        self._robot_state = None
+        self._target      = None   # 4×4 pose alvo do EE
+        self._enabled     = False
+
+        # Publicadores
+        self._pub_cmdvel  = rospy.Publisher('/cmd_vel',            Twist,              queue_size=1)
+        self._pub_armvel  = rospy.Publisher('/b166er/arm_vel_cmd', JointState,         queue_size=1)
+        self._pub_jacobian = rospy.Publisher('/b166er/wb_jacobian', Float64MultiArray, queue_size=1)
+
+        # Subscritores
+        rospy.Subscriber('/b166er/robot_state', RobotState,    self._cb_state)
+        rospy.Subscriber('/b166er/ee_target',   PoseStamped,   self._cb_target)
+
+        rospy.loginfo('[whole_body_planner] pronto — aguardando /b166er/ee_target')
+
+    # ------------------------------------------------------------------
+    def _cb_state(self, msg):
+        self._robot_state = msg
+
+    def _cb_target(self, msg):
+        self._target  = _pose_stamped_to_matrix(msg)
+        self._enabled = True
+        rospy.loginfo('[whole_body_planner] novo alvo recebido: '
+                      'pos=(%.3f, %.3f, %.3f)',
+                      msg.pose.position.x,
+                      msg.pose.position.y,
+                      msg.pose.position.z)
+
+    # ------------------------------------------------------------------
+    def _compute_wb_jacobian(self, state):
+        """Monta J_wb (6×8) a partir do RobotState."""
+        T_world_base = _odom_to_matrix(state.base_odom)
+        q_arm = np.array(state.q_arm)
+        return whole_body_jacobian(q_arm, T_world_base)
+
+    def _compute_error(self, state, T_target):
+        """Erro 6D entre EE atual (T265) e pose alvo."""
+        p = state.ee_pose.pose.position
+        o = state.ee_pose.pose.orientation
+        T_cur = quaternion_matrix([o.x, o.y, o.z, o.w])
+        T_cur[:3, 3] = [p.x, p.y, p.z]
+        return pose_error(T_cur, T_target)
+
+    def _apply_gain(self, err):
+        """Ganho proporcional fixo (fase 1 — será Fuzzy na fase 2)."""
+        v = np.zeros(6)
+        v[:3] = K_POS    * err[:3]
+        v[3:] = K_ORIENT * err[3:]
+        return v
+
+    def _null_space_objective(self, q_arm):
+        """
+        Objetivo secundário whole-body (8-DOF):
+        [0, 0, 0,  ∇limit(q_arm)]
+        — base não tem objetivo secundário aqui (sem preferência de pose).
+        """
+        grad_arm = joint_limit_gradient(q_arm)
+        return np.concatenate([np.zeros(3), self._ns_gain * grad_arm])
+
+    def _project_nonholonomic(self, q_dot_base, theta):
+        """
+        Projeta q̇_base = [ẋ, ẏ, θ̇] na constraint não-holonômica do Pioneer:
+        velocidade lateral (frame do corpo) = 0.
+
+        linear.x  = componente do ẋ,ẏ na direção de heading
+        angular.z = θ̇
+        """
+        v_forward = np.cos(theta) * q_dot_base[0] + np.sin(theta) * q_dot_base[1]
+        omega     = q_dot_base[2]
+        return v_forward, omega
+
+    def _publish_cmd_vel(self, q_dot_base, theta):
+        msg = Twist()
+        if self._nonholo:
+            v_fwd, omega = self._project_nonholonomic(q_dot_base, theta)
+            v_fwd  = float(np.clip(v_fwd,  -MAX_BASE_LIN, MAX_BASE_LIN))
+            omega  = float(np.clip(omega,  -MAX_BASE_ANG, MAX_BASE_ANG))
+            msg.linear.x  = v_fwd
+            msg.angular.z = omega
+        else:
+            msg.linear.x  = float(np.clip(q_dot_base[0], -MAX_BASE_LIN, MAX_BASE_LIN))
+            msg.linear.y  = float(np.clip(q_dot_base[1], -MAX_BASE_LIN, MAX_BASE_LIN))
+            msg.angular.z = float(np.clip(q_dot_base[2], -MAX_BASE_ANG, MAX_BASE_ANG))
+        self._pub_cmdvel.publish(msg)
+
+    def _publish_arm_vel(self, q_dot_arm, stamp):
+        msg          = JointState()
+        msg.header.stamp = stamp
+        msg.name     = JOINT_NAMES
+        msg.velocity = np.clip(q_dot_arm, -MAX_ARM_VEL, MAX_ARM_VEL).tolist()
+        self._pub_armvel.publish(msg)
+
+    def _publish_jacobian(self, J):
+        msg = Float64MultiArray()
+        d0  = MultiArrayDimension(label='rows', size=J.shape[0], stride=J.shape[0]*J.shape[1])
+        d1  = MultiArrayDimension(label='cols', size=J.shape[1], stride=J.shape[1])
+        msg.layout.dim = [d0, d1]
+        msg.data       = J.flatten().tolist()
+        self._pub_jacobian.publish(msg)
+
+    # ------------------------------------------------------------------
+    def spin(self):
+        rate = rospy.Rate(self._rate_hz)
+
+        while not rospy.is_shutdown():
+            if not self._enabled or self._robot_state is None:
+                self._pub_cmdvel.publish(Twist())
+                rate.sleep()
+                continue
+
+            state  = self._robot_state
+            now    = rospy.Time.now()
+
+            # Erro EE
+            err_EE = self._compute_error(state, self._target)
+            err_norm_pos    = np.linalg.norm(err_EE[:3])
+            err_norm_orient = np.linalg.norm(err_EE[3:])
+
+            # Para quando converge
+            if err_norm_pos < 0.005 and err_norm_orient < 0.02:
+                rospy.loginfo_throttle(2.0, '[whole_body_planner] alvo alcançado!')
+                self._pub_cmdvel.publish(Twist())
+                rate.sleep()
+                continue
+
+            # Jacobiana whole-body
+            J_wb  = self._compute_wb_jacobian(state)
+            J_pin = dls_pseudoinverse(J_wb, DLS_LAMBDA)
+            N     = null_space_projector(J_wb, J_pin)
+
+            # Velocidade cartesiana desejada (ganho fixo — fase 1)
+            xdot_d = self._apply_gain(err_EE)
+
+            # Tarefa principal
+            q_dot_task = J_pin @ xdot_d
+
+            # Objetivo secundário no espaço nulo
+            q_arm = np.array(state.q_arm)
+            q_dot_null = N @ self._null_space_objective(q_arm)
+
+            # Comando whole-body
+            q_dot_wb = q_dot_task + q_dot_null   # (8,)
+
+            q_dot_base = q_dot_wb[:3]
+            q_dot_arm  = q_dot_wb[3:]
+
+            # Theta do Pioneer para projeção não-holonômica
+            T_world_base = _odom_to_matrix(state.base_odom)
+            theta = np.arctan2(T_world_base[1, 0], T_world_base[0, 0])
+
+            # Publica
+            self._publish_cmd_vel(q_dot_base, theta)
+            self._publish_arm_vel(q_dot_arm, now)
+            self._publish_jacobian(J_wb)
+
+            rospy.loginfo_throttle(1.0,
+                '[wb_planner] err_pos=%.4fm err_ori=%.4frad | '
+                'base=[%.2f %.2f %.2f] arm=[%.2f %.2f %.2f %.2f %.2f]',
+                err_norm_pos, err_norm_orient,
+                *q_dot_base.round(3), *q_dot_arm.round(3))
+
+            rate.sleep()
+
+
+# ---------------------------------------------------------------------------
+if __name__ == '__main__':
+    try:
+        WholeBodyPlanner().spin()
+    except rospy.ROSInterruptException:
+        pass

--- a/src/b166er_whole_body_control/package.xml
+++ b/src/b166er_whole_body_control/package.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>b166er_whole_body_control</name>
+  <version>0.1.0</version>
+  <description>
+    Whole-body controller for b166er (Pioneer 3-AT + RV-M2).
+    Controls the full 8-DOF system (3 base + 5 arm) as a single kinematic chain
+    using T265 visual-inertial odometry as the only EE sensor (no joint encoders).
+  </description>
+
+  <maintainer email="marco.a.reis@gmail.com">Marco Reis</maintainer>
+  <license>MIT</license>
+
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <build_depend>message_generation</build_depend>
+  <build_depend>std_msgs</build_depend>
+  <build_depend>geometry_msgs</build_depend>
+  <build_depend>nav_msgs</build_depend>
+  <build_depend>sensor_msgs</build_depend>
+
+  <exec_depend>message_runtime</exec_depend>
+  <exec_depend>rospy</exec_depend>
+  <exec_depend>std_msgs</exec_depend>
+  <exec_depend>geometry_msgs</exec_depend>
+  <exec_depend>nav_msgs</exec_depend>
+  <exec_depend>sensor_msgs</exec_depend>
+  <exec_depend>tf2_ros</exec_depend>
+  <exec_depend>tf2_geometry_msgs</exec_depend>
+</package>

--- a/src/b166er_whole_body_control/src/b166er_whole_body_control/fuzzy_gain.py
+++ b/src/b166er_whole_body_control/src/b166er_whole_body_control/fuzzy_gain.py
@@ -1,0 +1,209 @@
+"""
+fuzzy_gain.py — Mamdani fuzzy gain scheduler para o controlador whole-body.
+
+Substitui o ganho fixo K do whole_body_planner por um ganho adaptativo
+que ajusta velocidade e amortecimento DLS em função do erro e sua variação.
+
+Entradas
+--------
+err_pos    : norma do erro de posição  (m)       ∈ [0, ∞)
+err_orient : norma do erro de orientação (rad)   ∈ [0, π]
+delta_err  : d(err_total)/dt  (m/s, ≈ rad/s)    ∈ (-∞, ∞)
+             negativo → erro diminuindo (melhorando)
+             positivo → erro aumentando (piorando)
+
+Saídas
+------
+k_pos      : ganho de velocidade linear  ∈ [0.1, 2.0]
+k_orient   : ganho de velocidade angular ∈ [0.1, 2.0]
+lambda_dls : amortecimento DLS           ∈ [0.01, 0.25]
+
+Regras (Mamdani, AND = mín, agregação = máx, defuzz = centróide)
+----------------------------------------------------------------
+err_pos / delta_err   IMPROVING   STABLE    WORSENING
+─────────────────────────────────────────────────────
+FAR    k_pos           FAST        FAST      MED
+       lambda           LOW         MED      HIGH
+
+MED    k_pos           MED         MED       SLOW
+       lambda           LOW         MED      HIGH
+
+NEAR   k_pos           SLOW        SLOW      SLOW
+       lambda           LOW         LOW       MED
+
+err_orient → k_orient:   FAR → FAST  |  MED → MED  |  NEAR → SLOW
+"""
+
+import numpy as np
+
+
+# ---------------------------------------------------------------------------
+# Funções de pertinência (membership functions)
+# ---------------------------------------------------------------------------
+
+def trimf(x, params):
+    """Triangular: params = [a, b, c]."""
+    a, b, c = params
+    return float(np.clip(
+        np.minimum((x - a) / (b - a + 1e-12),
+                   (c - x) / (c - b + 1e-12)), 0, 1))
+
+
+def trapmf(x, params):
+    """Trapezoidal: params = [a, b, c, d]."""
+    a, b, c, d = params
+    return float(np.clip(
+        np.minimum(
+            np.minimum((x - a) / (b - a + 1e-12), 1.0),
+            (d - x) / (d - c + 1e-12)), 0, 1))
+
+
+# ---------------------------------------------------------------------------
+# Universos de discurso e funções de pertinência por variável
+# ---------------------------------------------------------------------------
+
+# --- err_pos (m) ---
+def _ep_near(x):   return trapmf(x, [0.00, 0.00, 0.03, 0.08])
+def _ep_med(x):    return trimf(x,  [0.04, 0.12, 0.28])
+def _ep_far(x):    return trapmf(x, [0.18, 0.35, 1.00, 1.00])
+
+# --- err_orient (rad) ---
+def _eo_near(x):   return trapmf(x, [0.00, 0.00, 0.05, 0.15])
+def _eo_med(x):    return trimf(x,  [0.08, 0.20, 0.45])
+def _eo_far(x):    return trapmf(x, [0.25, 0.55, 3.14, 3.14])
+
+# --- delta_err (m/s), negativo = melhorando ---
+def _de_impr(x):   return trapmf(x, [-0.50, -0.50, -0.005, 0.00])
+def _de_stab(x):   return trimf(x,  [-0.005, 0.00,  0.010])
+def _de_wors(x):   return trapmf(x, [ 0.005, 0.02,  0.50, 0.50])
+
+# --- k_pos / k_orient (universo [0, 2]) ---
+_K_RANGE  = np.linspace(0.1, 2.0, 200)
+def _k_slow(x):    return trapmf(x, [0.10, 0.10, 0.35, 0.60])
+def _k_med(x):     return trimf(x,  [0.40, 0.80, 1.20])
+def _k_fast(x):    return trapmf(x, [0.90, 1.40, 2.00, 2.00])
+
+# --- lambda_dls (universo [0.01, 0.25]) ---
+_L_RANGE  = np.linspace(0.01, 0.25, 200)
+def _l_low(x):     return trapmf(x, [0.010, 0.010, 0.03, 0.06])
+def _l_med(x):     return trimf(x,  [0.040, 0.080, 0.14])
+def _l_high(x):    return trapmf(x, [0.100, 0.180, 0.25, 0.25])
+
+
+# ---------------------------------------------------------------------------
+# Motor de inferência Mamdani
+# ---------------------------------------------------------------------------
+
+def _centroid(universe, mf_values):
+    """Defuzzificação por centróide."""
+    denom = np.sum(mf_values)
+    if denom < 1e-10:
+        return float(universe[len(universe) // 2])
+    return float(np.sum(universe * mf_values) / denom)
+
+
+def _mamdani_kpos(ep_near, ep_med, ep_far, de_impr, de_stab, de_wors):
+    """9 regras para k_pos."""
+    rules = [
+        # (ativação,                      consequente)
+        (min(ep_far,  de_impr), _k_fast),
+        (min(ep_far,  de_stab), _k_fast),
+        (min(ep_far,  de_wors), _k_med),
+        (min(ep_med,  de_impr), _k_med),
+        (min(ep_med,  de_stab), _k_med),
+        (min(ep_med,  de_wors), _k_slow),
+        (min(ep_near, de_impr), _k_slow),
+        (min(ep_near, de_stab), _k_slow),
+        (min(ep_near, de_wors), _k_slow),
+    ]
+    agg = np.zeros_like(_K_RANGE)
+    for strength, mf in rules:
+        agg = np.maximum(agg, np.minimum(strength,
+                                          np.vectorize(mf)(_K_RANGE)))
+    return _centroid(_K_RANGE, agg)
+
+
+def _mamdani_korient(eo_near, eo_med, eo_far):
+    """3 regras para k_orient."""
+    rules = [
+        (eo_far,  _k_fast),
+        (eo_med,  _k_med),
+        (eo_near, _k_slow),
+    ]
+    agg = np.zeros_like(_K_RANGE)
+    for strength, mf in rules:
+        agg = np.maximum(agg, np.minimum(strength,
+                                          np.vectorize(mf)(_K_RANGE)))
+    return _centroid(_K_RANGE, agg)
+
+
+def _mamdani_lambda(ep_near, ep_med, ep_far, de_impr, de_stab, de_wors):
+    """9 regras para lambda_dls."""
+    rules = [
+        (min(ep_far,  de_impr), _l_low),
+        (min(ep_far,  de_stab), _l_med),
+        (min(ep_far,  de_wors), _l_high),
+        (min(ep_med,  de_impr), _l_low),
+        (min(ep_med,  de_stab), _l_med),
+        (min(ep_med,  de_wors), _l_high),
+        (min(ep_near, de_impr), _l_low),
+        (min(ep_near, de_stab), _l_low),
+        (min(ep_near, de_wors), _l_med),
+    ]
+    agg = np.zeros_like(_L_RANGE)
+    for strength, mf in rules:
+        agg = np.maximum(agg, np.minimum(strength,
+                                          np.vectorize(mf)(_L_RANGE)))
+    return _centroid(_L_RANGE, agg)
+
+
+# ---------------------------------------------------------------------------
+# Interface pública
+# ---------------------------------------------------------------------------
+
+class FuzzyGain:
+    """
+    Ganho adaptativo Mamdani para o controlador whole-body.
+
+    Uso
+    ---
+    fg = FuzzyGain()
+    k_pos, k_orient, lam = fg.compute(err_pos, err_orient, delta_err)
+    """
+
+    def compute(self, err_pos: float, err_orient: float,
+                delta_err: float = 0.0):
+        """
+        Parâmetros
+        ----------
+        err_pos    : norma do erro de posição (m)
+        err_orient : norma do erro de orientação (rad)
+        delta_err  : d(||err||)/dt  (m/s) — negativo = melhorando
+
+        Retorna
+        -------
+        k_pos    : float  — ganho de posição
+        k_orient : float  — ganho de orientação
+        lam      : float  — amortecimento DLS (lambda)
+        """
+        # Fuzzificação
+        ep_near = _ep_near(err_pos)
+        ep_med  = _ep_med(err_pos)
+        ep_far  = _ep_far(err_pos)
+
+        eo_near = _eo_near(err_orient)
+        eo_med  = _eo_med(err_orient)
+        eo_far  = _eo_far(err_orient)
+
+        de_impr = _de_impr(delta_err)
+        de_stab = _de_stab(delta_err)
+        de_wors = _de_wors(delta_err)
+
+        # Inferência + defuzzificação
+        k_pos    = _mamdani_kpos(ep_near, ep_med, ep_far,
+                                  de_impr, de_stab, de_wors)
+        k_orient = _mamdani_korient(eo_near, eo_med, eo_far)
+        lam      = _mamdani_lambda(ep_near, ep_med, ep_far,
+                                    de_impr, de_stab, de_wors)
+
+        return k_pos, k_orient, lam

--- a/src/b166er_whole_body_control/src/b166er_whole_body_control/kinematics.py
+++ b/src/b166er_whole_body_control/src/b166er_whole_body_control/kinematics.py
@@ -1,0 +1,287 @@
+"""
+kinematics.py — cinemática do b166er (Pioneer + RV-M2) em numpy puro.
+
+Cadeia completa:
+  world → base_link → top_plate → Base(braço) → J1 → L1 → J2 → L2
+        → J3 → L3 → J4 → L4 → J5 → L5 → CameraSupport → t265_link
+
+8-DOF whole-body: q_wb = [x_b, y_b, θ_b,  q1, q2, q3, q4, q5]
+                          ← 3 base →       ←— 5 braço —→
+"""
+
+import numpy as np
+
+# ---------------------------------------------------------------------------
+# Constantes
+# ---------------------------------------------------------------------------
+
+JOINT_NAMES   = ['J1', 'J2', 'J3', 'J4', 'J5']
+JOINT_LOWER   = np.array([-2.61799, -1.13446, -1.04720, -1.91986, -3.14159])
+JOINT_UPPER   = np.array([ 2.61799,  1.13446,  1.04720,  1.91986,  3.14159])
+
+# IK
+IK_MAX_ITER   = 200
+IK_TOL_POS    = 1e-4   # m
+IK_TOL_ORIENT = 1e-3   # rad
+IK_LAMBDA     = 0.05
+IK_DQ_STEP    = 1e-6
+
+
+# ---------------------------------------------------------------------------
+# Primitivas de transformação homogênea (4×4)
+# ---------------------------------------------------------------------------
+
+def _rotx(a):
+    c, s = np.cos(a), np.sin(a)
+    return np.array([[1,0,0,0],[0,c,-s,0],[0,s,c,0],[0,0,0,1]], dtype=float)
+
+def _roty(a):
+    c, s = np.cos(a), np.sin(a)
+    return np.array([[c,0,s,0],[0,1,0,0],[-s,0,c,0],[0,0,0,1]], dtype=float)
+
+def _rotz(a):
+    c, s = np.cos(a), np.sin(a)
+    return np.array([[c,-s,0,0],[s,c,0,0],[0,0,1,0],[0,0,0,1]], dtype=float)
+
+def _trans(x, y, z):
+    T = np.eye(4); T[:3, 3] = [x, y, z]; return T
+
+def _tf(xyz, rpy):
+    """Translação + RPY extrínseco (Rz·Ry·Rx)."""
+    T = np.eye(4)
+    T[:3, :3] = (_rotz(rpy[2]) @ _roty(rpy[1]) @ _rotx(rpy[0]))[:3, :3]
+    T[:3,  3] = xyz
+    return T
+
+T_BASELINK_ARM = _tf([0.003, 0, 0.294], [0, 0, 0])
+_T_L5_T265     = _trans(0, 0, -0.08) @ _tf([0, 0.075, -0.07], [0, 2.1, 1.57])
+
+
+def _adj(R):
+    """Adjunto 6×6 para transformar vetores de velocidade de frame."""
+    A = np.zeros((6, 6))
+    A[:3, :3] = R
+    A[3:, 3:] = R
+    return A
+
+
+# ---------------------------------------------------------------------------
+# Cinemática direta (FK)
+# ---------------------------------------------------------------------------
+
+def fk_arm(q):
+    """
+    FK completa: Base → t265_link.
+
+    Parâmetros
+    ----------
+    q : array (5,)  — ângulos [q1..q5] em rad
+
+    Retorna
+    -------
+    T : ndarray (4,4) — transform Base → t265_link
+    """
+    q1, q2, q3, q4, q5 = q
+    return (
+        _trans(0, 0, 0.4)    @ _rotz(q1)
+        @ _trans(0.12, 0, 0) @ _rotx(1.5708) @ _rotz(q2)
+        @ _trans(0.25, 0, 0) @ _rotz(q3)
+        @ _trans(0.2,  0, 0) @ _rotz(q4)
+        @ _roty(-1.5708)     @ _rotz(q5)
+        @ _T_L5_T265
+    )
+
+
+def fk_arm_joint_frames(q):
+    """
+    FK intermediária: retorna o frame de cada junta (antes da rotação)
+    e o frame do EE, todos no frame Base do braço.
+
+    Retorna
+    -------
+    frames : list de 5 ndarray (4,4)  — T_Base_Ji_pre para i=1..5
+    T_EE   : ndarray (4,4)            — T_Base_t265
+    """
+    q1, q2, q3, q4, q5 = q
+
+    T_J1_pre = _trans(0, 0, 0.4)
+    T_L1     = T_J1_pre @ _rotz(q1)
+
+    T_J2_pre = T_L1 @ _trans(0.12, 0, 0) @ _rotx(1.5708)
+    T_L2     = T_J2_pre @ _rotz(q2)
+
+    T_J3_pre = T_L2 @ _trans(0.25, 0, 0)
+    T_L3     = T_J3_pre @ _rotz(q3)
+
+    T_J4_pre = T_L3 @ _trans(0.2, 0, 0)
+    T_L4     = T_J4_pre @ _rotz(q4)
+
+    T_J5_pre = T_L4 @ _roty(-1.5708)
+    T_L5     = T_J5_pre @ _rotz(q5)
+
+    T_EE     = T_L5 @ _T_L5_T265
+
+    return [T_J1_pre, T_J2_pre, T_J3_pre, T_J4_pre, T_J5_pre], T_EE
+
+
+# ---------------------------------------------------------------------------
+# Jacobianas
+# ---------------------------------------------------------------------------
+
+def arm_jacobian_world(q, T_world_arm_base):
+    """
+    Jacobiana geométrica do braço no frame mundial (6×5).
+
+    Para cada junta revoluta i:
+      Velocidade linear : z_i × (p_EE - p_i)
+      Velocidade angular: z_i
+    onde z_i = eixo Z do frame pre-rotação de Ji, expresso no frame mundial.
+
+    Parâmetros
+    ----------
+    q                : array (5,)    — ângulos das juntas
+    T_world_arm_base : ndarray (4,4) — transform world → Base do braço
+    """
+    joint_frames, T_EE_base = fk_arm_joint_frames(q)
+
+    R_wb = T_world_arm_base[:3, :3]
+
+    # EE em frame mundial
+    p_EE_w = (T_world_arm_base @ np.append(T_EE_base[:3, 3], 1))[:3]
+
+    J = np.zeros((6, 5))
+    for i, T_ji in enumerate(joint_frames):
+        z_w = R_wb @ T_ji[:3, 2]                              # eixo Z em frame mundial
+        p_i_w = (T_world_arm_base @ np.append(T_ji[:3, 3], 1))[:3]
+        r = p_EE_w - p_i_w
+        J[:3, i] = np.cross(z_w, r)
+        J[3:, i] = z_w
+
+    return J
+
+
+def base_jacobian_world(T_world_base, p_EE_world):
+    """
+    Jacobiana da base Pioneer (x_b, y_b, θ_b) sobre o EE, frame mundial (6×3).
+
+    ẋ_EE = ẋ_b − r_y·θ̇_b
+    ẏ_EE = ẏ_b + r_x·θ̇_b
+    ż_EE = 0
+    ω_z  = θ̇_b
+
+    onde r = p_EE − p_base  (frame mundial).
+    """
+    r = p_EE_world - T_world_base[:3, 3]
+
+    J = np.zeros((6, 3))
+    J[0, 0] =  1        # ẋ_EE / ẋ_base
+    J[1, 1] =  1        # ẏ_EE / ẏ_base
+    J[0, 2] = -r[1]     # ẋ_EE / θ̇_base
+    J[1, 2] =  r[0]     # ẏ_EE / θ̇_base
+    J[5, 2] =  1        # ω_z_EE / θ̇_base
+    return J
+
+
+def whole_body_jacobian(q, T_world_base):
+    """
+    Jacobiana whole-body J_wb (6×8) = [J_base | J_arm].
+
+    q_wb = [x_b, y_b, θ_b, q1, q2, q3, q4, q5]
+
+    Parâmetros
+    ----------
+    q            : array (5,) — ângulos das juntas do braço
+    T_world_base : ndarray (4,4) — transform world → base_link do Pioneer
+    """
+    T_world_arm_base = T_world_base @ T_BASELINK_ARM
+
+    joint_frames, T_EE_base = fk_arm_joint_frames(q)
+    p_EE_world = (T_world_arm_base @ np.append(T_EE_base[:3, 3], 1))[:3]
+
+    J_base = base_jacobian_world(T_world_base, p_EE_world)
+    J_arm  = arm_jacobian_world(q, T_world_arm_base)
+
+    return np.hstack([J_base, J_arm])   # (6×8)
+
+
+# ---------------------------------------------------------------------------
+# Controle: DLS pseudoinversa + projeção no espaço nulo
+# ---------------------------------------------------------------------------
+
+def dls_pseudoinverse(J, lam=IK_LAMBDA):
+    """Pseudoinversa damped least-squares: J^T (J J^T + λ²I)^{-1}."""
+    m = J.shape[0]
+    return J.T @ np.linalg.solve(J @ J.T + lam**2 * np.eye(m), np.eye(m))
+
+
+def null_space_projector(J, J_pinv):
+    """(I − J†J) — projeta para o espaço nulo de J."""
+    n = J.shape[1]
+    return np.eye(n) - J_pinv @ J
+
+
+def joint_limit_gradient(q_arm):
+    """
+    Gradiente do custo de limite de junta para objetivo secundário.
+    Empurra cada junta em direção ao centro de seu intervalo.
+    """
+    q_mid   = (JOINT_UPPER + JOINT_LOWER) / 2.0
+    q_range = (JOINT_UPPER - JOINT_LOWER) / 2.0
+    return -(q_arm - q_mid) / (q_range ** 2)
+
+
+# ---------------------------------------------------------------------------
+# IK do braço isolado (usado pelo state_estimator)
+# ---------------------------------------------------------------------------
+
+def _T_to_6vec(T):
+    """4×4 → 6-vetor [pos, skew_sym(R)] para Jacobiano numérico."""
+    pos = T[:3, 3]
+    R   = T[:3, :3]
+    dw  = np.array([R[2,1]-R[1,2], R[0,2]-R[2,0], R[1,0]-R[0,1]]) * 0.5
+    return np.concatenate([pos, dw])
+
+
+def pose_error(T_current, T_target):
+    """
+    Erro 6-vetor [Δp, Δω] de SE(3).
+    Δp  = p_target − p_current
+    Δω  = parte vetorial de R_err = R_target · R_current^T
+    """
+    dp    = T_target[:3, 3] - T_current[:3, 3]
+    R_err = T_target[:3, :3] @ T_current[:3, :3].T
+    dw    = np.array([R_err[2,1]-R_err[1,2],
+                      R_err[0,2]-R_err[2,0],
+                      R_err[1,0]-R_err[0,1]]) * 0.5
+    return np.concatenate([dp, dw])
+
+
+def ik_arm(T_target, q_init=None):
+    """
+    IK numérica para o braço RV-M2 (Base → t265_link).
+    DLS com Jacobiano central de diferenças finitas.
+
+    Retorna (q, converged, res_pos, res_orient).
+    """
+    q = np.zeros(5) if q_init is None else np.array(q_init, dtype=float)
+
+    for _ in range(IK_MAX_ITER):
+        T_cur  = fk_arm(q)
+        err    = pose_error(T_cur, T_target)
+        rp, ro = np.linalg.norm(err[:3]), np.linalg.norm(err[3:])
+
+        if rp < IK_TOL_POS and ro < IK_TOL_ORIENT:
+            return q, True, rp, ro
+
+        # Jacobiano de FK (diferenças centrais)
+        J = np.zeros((6, 5))
+        for i in range(5):
+            dq_i    = np.zeros(5); dq_i[i] = IK_DQ_STEP
+            J[:, i] = (_T_to_6vec(fk_arm(q + dq_i))
+                       - _T_to_6vec(fk_arm(q - dq_i))) / (2 * IK_DQ_STEP)
+
+        dq = J.T @ np.linalg.solve(J @ J.T + IK_LAMBDA**2 * np.eye(6), err)
+        q  = np.clip(q + dq, JOINT_LOWER, JOINT_UPPER)
+
+    T_cur = fk_arm(q); err = pose_error(T_cur, T_target)
+    return q, False, np.linalg.norm(err[:3]), np.linalg.norm(err[3:])


### PR DESCRIPTION
## Summary

Implementação da Fase 1 do controlador whole-body do b166er: Pioneer 3-AT e braço RV-M2 tratados como um único sistema de 8-DOF, com path planning unificado — nenhuma separação entre navegação e manipulação.

### Pacote `b166er_whole_body_control`

- **`kinematics.py`** — cinemática pura em numpy: FK analítica (Base→t265_link), Jacobiana geométrica whole-body J_wb (6×8) = [J_base | J_arm], pseudoinversa DLS, projetor de espaço nulo, IK numérica (convergência < 0,1 mm / < 1 mrad testada)
- **`state_estimator.py`** — estima ângulos de junta do braço *sem encoders* via IK(T265 + Pioneer odom); publica `RobotState` com estado completo a 20 Hz
- **`whole_body_planner.py`** — baseline com ganho fixo (referência comparativa)
- **`fuzzy_gain.py` + `fuzzy_wb_controller.py`** — ganho Mamdani adaptativo (3 entradas: err_pos, err_orient, delta_err → k_pos, k_orient, λ_dls); comportamento: rápido longe do alvo, suave na aproximação, λ alto ao divergir
- **`b166er_wb.launch`** — sobe o sistema completo em um comando (`mode:=sim` ou `mode:=hardware`); inclui drivers Pioneer, T265, RV-M2 e IMU no modo hardware

### URDF — posições reais dos sensores

- Braço RV-M2 centralizado nos eixos da plataforma original (`xyz="0 0 0.02"`)
- Hokuyo UST-05LX assentado no top_plate (`z=0.025`)
- IMU Sparton AHRS-8 na face traseira de L1 — bunda do manipulador (`xyz="-0.05 0 0.02"`) — confirmado por foto do robô real
- `b166er_rviz.launch`: `use_sim_time=false` para evitar trava sem roscore Gazebo

## Test plan

- [x] `catkin build b166er_whole_body_control` — sem erros
- [x] FK: `fk_arm([0,0,0,0,0])` → posição EE correta em frame Base
- [x] IK round-trip: `ik_arm(fk_arm(q_true))` converge < 0,1 mm
- [x] J_wb: shape (6,8), rank 6, espaço nulo = 2 DOF (8−6)
- [x] FuzzyGain: longe+melhorando→k=1.56,λ=0.03 | perto+estável→k=0.30,λ=0.03
- [x] Sensores validados visualmente no RViz (IMU dentro do paralelepípedo L1)
- [ ] Validação em hardware real (laboratório — próxima fase)

🤖 Generated with [Claude Code](https://claude.com/claude-code)