### PR TITLE
Fase 3: estabilização do braço e da simulação Gazebo

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,16 @@ Pioneer 3-AT base + Mitsubishi RV-M2 arm, controlled via ROS Noetic (RoboStack) 
 | Hokuyo UST-05LX (Smart URG) | Ethernet | IP a definir |
 | Intel NUC 5i5RYH | ROS master | `b166er-nuc.local` |
 
+## Packages
+
+| Package | Description |
+|---|---|
+| `b166er_robot` | URDF, launch files, hardware drivers |
+| `b166er_whole_body_control` | Whole-body controller (8-DOF: Pioneer + RV-M2) |
+| `movemaster_control` | RV-M2 driver (serial) |
+| `sparton_ahrs8_driver` | IMU driver |
+| `rosaria` | Pioneer driver (AriaCoda) |
+
 ## Build
 
 ROS Noetic is provided by [RoboStack](https://robostack.github.io/) (conda-based).
@@ -66,15 +76,48 @@ bash setup/udev_pioneer.sh     # /dev/ttyPioneer udev rule
 
 ## Launch
 
+### Whole-body control (unified launch)
+
+```bash
+source devel/setup.zsh
+
+# Gazebo simulation (recommended for development)
+roslaunch b166er_whole_body_control b166er_wb.launch mode:=gazebo gui:=true rviz:=true
+
+# Hardware (Pioneer + T265 + RV-M2 + IMU)
+roslaunch b166er_whole_body_control b166er_wb.launch mode:=hardware rviz:=true
+
+# Kinematic preview only (RViz + joint_state_publisher_gui)
+roslaunch b166er_whole_body_control b166er_wb.launch mode:=sim
+```
+
+### Send an EE target (Gazebo, safe workspace: z ≥ 0.60 m in odom frame)
+
+```bash
+rostopic pub -r 5 /b166er/ee_target geometry_msgs/PoseStamped \
+  '{header: {frame_id: odom}, pose: {position: {x: 0.55, y: 0.10, z: 0.70}, orientation: {w: 1.0}}}'
+```
+
+### Legacy launches
+
 ```bash
 # RViz preview (no hardware)
 roslaunch b166er_robot b166er_base.launch
 
-# Pioneer base
+# Pioneer base only
 roslaunch b166er_robot pioneer_hardware.launch
-
-# Full hardware stack
-roslaunch b166er_robot pioneer_hardware.launch &
-roslaunch b166er_robot imu_hardware.launch &
-roslaunch b166er_robot movemaster_hardware.launch
 ```
+
+## Whole-body control architecture
+
+The RV-M2 arm has no accessible joint encoders. Control is performed in
+**task space** using the T265 camera on the end-effector as a 6-DOF position sensor,
+with an 8-DOF Mamdani fuzzy controller (Pioneer base + arm joints):
+
+```
+T265 (EE pose) ──► state_estimator (IK) ──► fuzzy_wb_controller ──► cmd_vel + arm_vel_cmd
+Pioneer odom  ──►                                                 └──► arm_vel_integrator
+```
+
+See [`src/b166er_whole_body_control/docs/controle_sem_encoders.md`](src/b166er_whole_body_control/docs/controle_sem_encoders.md)
+for the full technical description.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -46,7 +46,7 @@ T265 (EE) + Pioneer odom → state_estimator (IK) → Fuzzy WB Controller (8-DOF
 
 ---
 
-## Fase 3 — Estabilização do braço e da simulação ✅ concluída
+## Fase 3 — Estabilização do braço e da simulação ✅ concluída (PR #20)
 
 **Problema original:** braço oscilava em torno do equilíbrio após o warm-start
 (PID de posição sem compensação de gravidade). Durante a fase, o escopo cresceu:

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -46,40 +46,49 @@ T265 (EE) + Pioneer odom → state_estimator (IK) → Fuzzy WB Controller (8-DOF
 
 ---
 
-## Fase 3 — Redução do Shaking (braço) 🔄 próxima etapa
+## Fase 3 — Estabilização do braço e da simulação ✅ concluída
 
-**Problema:** braço oscila em torno da posição de equilíbrio após o warm-start
-porque os controladores PID de posição (ros_control) não têm compensação de
-gravidade — o torque gravitacional não é cancelado, gerando oscilação amortecida.
+**Problema original:** braço oscilava em torno do equilíbrio após o warm-start
+(PID de posição sem compensação de gravidade). Durante a fase, o escopo cresceu:
+o Pioneer deslocava sozinho no Gazebo e as rodas apareciam colapsadas na origem
+do RViz — ambos exigiram diagnóstico ao vivo na simulação.
 
-**Abordagem em etapas:**
-
-### 3.1 Diagnóstico (medir a oscilação)
+### 3.1 Shaking do braço (causa: gravidade não compensada)
 | Etapa | Status |
 |---|---|
-| Gravar `ros_bag` dos tópicos `/joint_states` e `/b166er/robot_state` | ⬜ |
-| Plotar q(t) por junta e identificar frequência natural e amplitude | ⬜ |
-| Identificar quais juntas oscilam mais (esperado: J2 e J3, mais pesadas) | ⬜ |
+| Feedforward de gravidade no `gazebo_arm_bridge`: q_cmd = q + K_ff·τ_grav/P | ✅ |
+| `gravity_torque_arm(q)` em `kinematics.py` (massas do manual Mitsubishi) | ✅ |
+| Ganhos PID por junta em `arm_controllers.yaml` (P/D dimensionados, I=0) | ✅ |
+| Sequência load → unpause → switch no `arm_controller_loader` (sem deadlock) | ✅ |
 
-### 3.2 Feedforward de gravidade no bridge (simulação)
+### 3.2 Rodas colapsadas no RViz ("roda branca")
 | Etapa | Status |
 |---|---|
-| Calcular torque gravitacional por junta: τ_grav(q) = ∂U/∂q | ⬜ |
-| Adicionar termo feedforward em `gazebo_arm_bridge`: `q_cmd += K_ff · τ_grav · dt` | ⬜ |
-| Validar redução da oscilação no Gazebo (comparar bag antes/depois) | ⬜ |
+| Causa: `rospy.WallRate` inexistente matava o `pioneer_wheel_state_pub` após 1 publish | ✅ |
+| TF das rodas publicado a 50 Hz em wall-time (imune a pausas do sim_time) | ✅ |
 
-### 3.3 Ajuste PID (se feedforward não for suficiente)
+### 3.3 Deslocamento espontâneo do Pioneer no Gazebo
 | Etapa | Status |
 |---|---|
-| Reduzir P de J2/J3 (menos agressividade) e aumentar D (mais amortecimento) | ⬜ |
-| Testar combinação P/D para criticamente amortecido sem lentidão excessiva | ⬜ |
+| Diagnóstico ao vivo: robô inteiro em queda perpétua (vz≈-0.08 m/s), rodas paradas | ✅ |
+| Causa: contato subamortecido (kp=1e6, kd=100 → ζ≈1,6%) + braço horizontal retificando a vibração | ✅ |
+| kd 100 → 1e4 nas 4 rodas; remoção de bloco `<gazebo>` duplicado; spawn a 1 mm do chão | ✅ |
+| Spawn em q=0 (sem `-J J2 0.5`, que corria contra o unpause e chutava o chassi) | ✅ |
+| Fricção de junta das rodas 0,5 N·m (frenagem passiva sem stiction no ajuste fino) | ✅ |
 
-### 3.4 Validação final
-| Etapa | Status |
+### 3.4 Validação final (medida no Gazebo)
+| Critério | Resultado |
 |---|---|
-| Amplitude de oscilação < 0.05 rad em steady-state | ⬜ |
-| IK converge sem warnings por ≥ 60 s contínuos | ⬜ |
-| EE tracking de alvo estático com erro < 5 mm | ⬜ |
+| Amplitude de oscilação < 0.05 rad em steady-state | ✅ dq ≈ 0.0002 rad/s |
+| IK converge sem warnings por ≥ 60 s contínuos | ✅ `ik_converged` estável em sessão longa |
+| EE tracking de alvo estático com erro < 5 mm | ✅ 4,7 mm (alvo longitudinal, base+braço) |
+| Piso de velocidade da base (10 mm/s) + histerese no fuzzy | ✅ |
+
+**Limitação conhecida (decisão de projeto em aberto):** alvos com erro
+puramente lateral estacionam a ~99 mm — a projeção não-holonômica não gera
+esterçamento (v_fwd ≈ 0 para erro ⊥ heading) e o braço não compensa sem
+violar a orientação do EE. Estratégias candidatas: manobra girar-avançar-girar,
+relaxamento transitório da orientação, ou alinhamento de heading via espaço nulo.
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,55 +1,129 @@
 # Roadmap b166er
 
-Dois pilares de integração para o doutorado em robótica móvel (UTFPR):
-o robô deve navegar autonomamente até um objetivo definido pelo usuário
-e manipular objetos usando servovisão Fuzzy sem encoders.
+Doutorado UTFPR — robótica móvel com manipulação: o b166er deve navegar
+autonomamente e manipular objetos via servovisão Fuzzy whole-body sem encoders
+de junta.
+
+**Arquitetura central:**
+T265 (EE) + Pioneer odom → state_estimator (IK) → Fuzzy WB Controller (8-DOF)
+→ cmd_vel (base) + arm_vel_cmd (braço)
 
 ---
 
-## Pilar 1 — Navegação Autônoma (Base + T265)
-
-**Meta:** usuário define um ponto objetivo → plataforma navega sozinha
-usando a T265 como sensor de pose visual-inercial.
+## Fase 1 — Infraestrutura e Modelagem ✅ concluída
 
 | Etapa | Status |
 |---|---|
-| T265: udev, launch nodelet, validado Shiroi + NUC | ✅ |
-| Pioneer 3-AT: teste básico `/cmd_vel` e odometria | ⬜ |
+| URDF unificado: Pioneer 3-AT + RV-M2 + T265 + Hokuyo + IMU | ✅ |
+| Posicionamento dos sensores por foto do robô real | ✅ |
+| Parâmetros DH e limites de junta do RV-M2 (manual oficial) | ✅ |
+| Massas RV-M2 escaladas para 28 kgf (manual Mitsubishi) | ✅ |
+| Driver Sparton AHRS-8: launch + tópico `/imu/data` | ✅ |
+| NUC: auto-login GDM + roscore systemd + udev rules | ✅ |
+| Bug Gazebo resolvido: migração para Python 3.12 + gazebo-ros 2.9.3 | ✅ |
+
+---
+
+## Fase 2 — Controle Whole-Body no Gazebo ✅ concluída (PR #18)
+
+**Meta:** pipeline end-to-end validado em simulação:
+`ee_target → fuzzy WB → cmd_vel + arm_vel_cmd`
+
+| Etapa | Status |
+|---|---|
+| Cinemática direta FK + Jacobiana whole-body 8-DOF | ✅ |
+| `state_estimator`: T265 + odom → IK (DLS) → q_arm estimado | ✅ |
+| Seed do IK sincronizado por timestamp do T265 (buffer deque) | ✅ |
+| `fuzzy_wb_controller`: Mamdani (k_pos, k_orient, λ adaptativos) | ✅ |
+| `arm_vel_integrator`: integra q̇ → posição para hardware | ✅ |
+| `gazebo_arm_bridge`: equivalente para simulação (ros_control) | ✅ |
+| `gazebo_sensor_sim`: FK sintético → /t265/odom/sample | ✅ |
+| Launch unificado `b166er_wb.launch` (sim / hardware / gazebo) | ✅ |
+| 4 rodas do Pioneer visíveis no RViz (pioneer_wheel_state_pub) | ✅ |
+| Posição inicial J2=0.5 rad no spawn (evita colisão com Pioneer) | ✅ |
+| Workspace seguro documentado: z ≥ 0.60 m (frame odom) | ✅ |
+| Documentação técnica: controle sem encoders + diagrama de blocos | ✅ |
+
+---
+
+## Fase 3 — Redução do Shaking (braço) 🔄 próxima etapa
+
+**Problema:** braço oscila em torno da posição de equilíbrio após o warm-start
+porque os controladores PID de posição (ros_control) não têm compensação de
+gravidade — o torque gravitacional não é cancelado, gerando oscilação amortecida.
+
+**Abordagem em etapas:**
+
+### 3.1 Diagnóstico (medir a oscilação)
+| Etapa | Status |
+|---|---|
+| Gravar `ros_bag` dos tópicos `/joint_states` e `/b166er/robot_state` | ⬜ |
+| Plotar q(t) por junta e identificar frequência natural e amplitude | ⬜ |
+| Identificar quais juntas oscilam mais (esperado: J2 e J3, mais pesadas) | ⬜ |
+
+### 3.2 Feedforward de gravidade no bridge (simulação)
+| Etapa | Status |
+|---|---|
+| Calcular torque gravitacional por junta: τ_grav(q) = ∂U/∂q | ⬜ |
+| Adicionar termo feedforward em `gazebo_arm_bridge`: `q_cmd += K_ff · τ_grav · dt` | ⬜ |
+| Validar redução da oscilação no Gazebo (comparar bag antes/depois) | ⬜ |
+
+### 3.3 Ajuste PID (se feedforward não for suficiente)
+| Etapa | Status |
+|---|---|
+| Reduzir P de J2/J3 (menos agressividade) e aumentar D (mais amortecimento) | ⬜ |
+| Testar combinação P/D para criticamente amortecido sem lentidão excessiva | ⬜ |
+
+### 3.4 Validação final
+| Etapa | Status |
+|---|---|
+| Amplitude de oscilação < 0.05 rad em steady-state | ⬜ |
+| IK converge sem warnings por ≥ 60 s contínuos | ⬜ |
+| EE tracking de alvo estático com erro < 5 mm | ⬜ |
+
+---
+
+## Fase 4 — Validação em Hardware Real
+
+**Pré-requisito:** Fases 2 e 3 concluídas.
+
+| Etapa | Status |
+|---|---|
+| Conectar braço RV-M2 via rosserial (Arduino) | ⬜ |
+| Validar `arm_vel_integrator` em hardware (velocidade → posição serial) | ⬜ |
+| Calibração hand-eye: T265 → flange do RV-M2 | ⬜ |
+| Teste de rastreamento: alvo estático com braço real | ⬜ |
+| Teste de rastreamento: alvo em movimento lento (servovisão) | ⬜ |
+| Ajuste PID / feedforward para dinâmica real (diferente da simulação) | ⬜ |
+
+---
+
+## Fase 5 — Navegação Autônoma (Pilar 1)
+
+| Etapa | Status |
+|---|---|
+| Pioneer 3-AT: validar `/cmd_vel` em hardware | ⬜ |
 | `robot_localization`: fusão odometria Pioneer + T265 + IMU | ⬜ |
-| `move_base`: planejamento de trajetória até objetivo | ⬜ |
+| Hokuyo UST-05LX: IP fixo na rede Ethernet + launch | ⬜ |
+| `move_base`: planejamento de trajetória com mapa local | ⬜ |
 | Teste integrado: ponto A → ponto B autônomo | ⬜ |
 
 ---
 
-## Pilar 2 — Manipulação com Servovisão Fuzzy (Braço + T265)
+## Fase 6 — Integração Whole-Body + Navegação
 
-**Meta:** T265 detecta posição do end-effector → Fuzzy ajusta eixos
-do RV-M2 para atingir alvo visual sem encoders.
-
-| Etapa | Status |
-|---|---|
-| Arduino firmware: controle PWM dos 5 eixos do RV-M2 | ⬜ |
-| rosserial: NUC ↔ Arduino (comando + feedback) | ⬜ |
-| URDF/Xacro: cinemática direta do RV-M2 | ⬜ |
-| Lógica Fuzzy: erro visual → delta PWM por eixo | ⬜ |
-| Calibração câmera-braço (hand-eye T265 → flange) | ⬜ |
-| Teste integrado: servovisão até alvo estático | ⬜ |
-
----
-
-## Infraestrutura Compartilhada
+**Meta final:** robô navega até a peça e a manipula de forma autônoma.
 
 | Etapa | Status |
 |---|---|
-| NUC: auto-login GDM + roscore systemd | ✅ |
-| Sparton AHRS-8 IMU: driver + launch | ⬜ |
-| URDF unificado (Pioneer + RV-M2 + T265 + Hokuyo + IMU) | ✅ |
-| Hokuyo UST-05LX: IP fixo na rede Ethernet | ⬜ |
+| Integrar planner de navegação com whole-body controller | ⬜ |
+| Coordenação base-braço: navegar enquanto posiciona EE | ⬜ |
 | E-Stop físico (relé) + watchdog ROS | ⬜ |
+| Demonstração completa: navegação + manipulação autônoma | ⬜ |
 
 ---
 
-## Setup por máquina
+## Scripts de Setup
 
 | Script | Finalidade |
 |---|---|

--- a/src/b166er_robot/launch/simulation/b166er_gazebo.launch
+++ b/src/b166er_robot/launch/simulation/b166er_gazebo.launch
@@ -16,9 +16,10 @@
     <arg name="gui"          value="$(arg gui)"/>
   </include>
 
-  <!-- z=-0.02: rodas a 6 mm do chão (base_link descansa em z≈-0.026).
-       Antes era z=0.05 → Pioneer caía 7,6 cm após o unpause, causando
-       deslocamento horizontal pela inércia do braço.
+  <!-- z=-0.025: rodas a ~1 mm do chão (base_link descansa em z≈-0.026),
+       minimizando o impulso vertical no unpause que excitava o modo de
+       quicar do contato. Antes era z=0.05 → Pioneer caía 7,6 cm após o
+       unpause, causando deslocamento horizontal pela inércia do braço.
        Sem -J: o set_model_configuration do spawn_model corre contra o
        unpause do arm_controller_loader e o J2=0.5 não era aplicado — o
        braço ficava em 0 enquanto o gazebo_arm_bridge comandava 0.5,
@@ -26,7 +27,7 @@
        Spawn em q=0 (dentro dos limites ±1.13 rad de J2) é determinístico
        e coincide com o q_spawn do bridge. -->
   <node name="spawn_b166er" pkg="gazebo_ros" type="spawn_model"
-        args="-urdf -model b166er -param robot_description -z -0.02"/>
+        args="-urdf -model b166er -param robot_description -z -0.025"/>
 
   <node if="$(arg robot_state_pub)"
         name="robot_state_publisher"

--- a/src/b166er_robot/launch/simulation/b166er_gazebo.launch
+++ b/src/b166er_robot/launch/simulation/b166er_gazebo.launch
@@ -1,9 +1,4 @@
 <launch>
-  <!-- Preview estético do b166er no Gazebo (sem controle, massas/inércias
-       provisórias) — só para confirmar que o modelo spawna corretamente.
-       Não serve para validar física real; trocar as inertials por valores
-       medidos antes de usar para controle/planejamento. -->
-
   <!-- gui:=false para rodar headless (ex: chamado pelo b166er_wb.launch) -->
   <arg name="gui"              default="true"/>
   <!-- robot_state_pub:=false quando o launch pai já sobe o nó -->
@@ -12,16 +7,15 @@
   <param name="robot_description"
          command="$(find xacro)/xacro $(find b166er_robot)/urdf/b166er.urdf.xacro"/>
 
+  <!-- Inicia pausado: garante que o braço não cai antes dos controladores
+       carregarem. O arm_controller_loader despausa após carregar tudo. -->
   <include file="$(find gazebo_ros)/launch/empty_world.launch">
     <arg name="world_name"   value="$(find b166er_robot)/worlds/empty.world"/>
-    <arg name="paused"       value="false"/>
+    <arg name="paused"       value="true"/>
     <arg name="use_sim_time" value="true"/>
     <arg name="gui"          value="$(arg gui)"/>
   </include>
 
-  <!-- -J J2 0.5: braço começa com ombro elevado (29°) para não cair
-       dentro do chassi do Pioneer durante os ~0.5 s antes dos controladores
-       ros_control carregarem. Posição segura após a queda: J2 ≈ 0.33 rad. -->
   <node name="spawn_b166er" pkg="gazebo_ros" type="spawn_model"
         args="-urdf -model b166er -param robot_description -z 0.05 -J J2 0.5"/>
 

--- a/src/b166er_robot/launch/simulation/b166er_gazebo.launch
+++ b/src/b166er_robot/launch/simulation/b166er_gazebo.launch
@@ -16,8 +16,11 @@
     <arg name="gui"          value="$(arg gui)"/>
   </include>
 
+  <!-- z=-0.02: rodas a 6 mm do chão (base_link descansa em z≈-0.026).
+       Antes era z=0.05 → Pioneer caía 7,6 cm após o unpause, causando
+       deslocamento horizontal pela inércia do braço. -->
   <node name="spawn_b166er" pkg="gazebo_ros" type="spawn_model"
-        args="-urdf -model b166er -param robot_description -z 0.05 -J J2 0.5"/>
+        args="-urdf -model b166er -param robot_description -z -0.02 -J J2 0.5"/>
 
   <node if="$(arg robot_state_pub)"
         name="robot_state_publisher"

--- a/src/b166er_robot/launch/simulation/b166er_gazebo.launch
+++ b/src/b166er_robot/launch/simulation/b166er_gazebo.launch
@@ -18,9 +18,15 @@
 
   <!-- z=-0.02: rodas a 6 mm do chão (base_link descansa em z≈-0.026).
        Antes era z=0.05 → Pioneer caía 7,6 cm após o unpause, causando
-       deslocamento horizontal pela inércia do braço. -->
+       deslocamento horizontal pela inércia do braço.
+       Sem -J: o set_model_configuration do spawn_model corre contra o
+       unpause do arm_controller_loader e o J2=0.5 não era aplicado — o
+       braço ficava em 0 enquanto o gazebo_arm_bridge comandava 0.5,
+       gerando pico de torque (P=300 × 0.5 rad) que chutava o chassi.
+       Spawn em q=0 (dentro dos limites ±1.13 rad de J2) é determinístico
+       e coincide com o q_spawn do bridge. -->
   <node name="spawn_b166er" pkg="gazebo_ros" type="spawn_model"
-        args="-urdf -model b166er -param robot_description -z -0.02 -J J2 0.5"/>
+        args="-urdf -model b166er -param robot_description -z -0.02"/>
 
   <node if="$(arg robot_state_pub)"
         name="robot_state_publisher"

--- a/src/b166er_robot/urdf/pioneer3at/pioneer3at-m.urdf.xacro
+++ b/src/b166er_robot/urdf/pioneer3at/pioneer3at-m.urdf.xacro
@@ -211,6 +211,10 @@
 
     <gazebo reference="p3at_front_${side}_wheel">
       <material value="Gazebo/Black"/>
+      <kp>1000000.0</kp>
+      <kd>100.0</kd>
+      <mu1>0.9</mu1>
+      <mu2>0.9</mu2>
     </gazebo>
     <joint name="p3at_front_${side}_wheel_joint" type="continuous">
       <axis xyz="0 1 0"/>
@@ -443,8 +447,13 @@
 
   <xacro:macro name="p3at_gazebo_ext">
     <gazebo>
-      <!--This plugin was removed to avoid sending over the network a lot of information. A reduced version of its topics is sent by the following plugin-->
-      <plugin name="skid_steer_drive_controller" filename="libgazebo_ros_skid_steer_drive_pioneer3at.so">
+      <!-- libgazebo_ros_skid_steer_drive_pioneer3at.so não existe em nenhuma instalação
+           conhecida e o Gazebo falhava silenciosamente ao carregar o plugin, deixando as
+           rodas completamente livres (sem controle de velocidade).
+           Corrigido para o plugin padrão do ROS Noetic. commandTopic com path absoluto
+           (/cmd_vel) ignora o robotNamespace e se conecta diretamente ao tópico
+           publicado pelo fuzzy_wb_controller. -->
+      <plugin name="skid_steer_drive_controller" filename="libgazebo_ros_skid_steer_drive.so">
         <updateRate>100.0</updateRate>
         <robotNamespace>${robot_name}</robotNamespace>
         <leftFrontJoint>p3at_front_left_wheel_joint</leftFrontJoint>
@@ -454,9 +463,8 @@
         <wheelSeparation>0.27</wheelSeparation>
         <wheelDiameter>0.17</wheelDiameter>
         <robotBaseFrame>base_link</robotBaseFrame>
-        <MaxForce>5.0</MaxForce>
         <torque>20</torque>
-        <commandTopic>cmd_vel</commandTopic>
+        <commandTopic>/cmd_vel</commandTopic>
         <odometryTopic>odom</odometryTopic>
         <odometryFrame>odom</odometryFrame>
         <broadcastTF>false</broadcastTF>

--- a/src/b166er_robot/urdf/pioneer3at/pioneer3at-m.urdf.xacro
+++ b/src/b166er_robot/urdf/pioneer3at/pioneer3at-m.urdf.xacro
@@ -216,7 +216,7 @@
       <axis xyz="0 1 0"/>
       <anchor xyz="0 0 0"/>
       <limit effort="10" velocity="10"/>
-      <dynamics damping="1.0" friction="3.0"/>
+      <dynamics damping="1.0" friction="0.5"/>
       <origin xyz="0 0 0" rpy="0 0 0"/>
       <parent link="p3at_front_${side}_hub"/>
       <child link="p3at_front_${side}_wheel"/>
@@ -321,7 +321,7 @@
       <axis xyz="0 1 0"/>
       <anchor xyz="0 0 0"/>
       <limit effort="10" velocity="10"/>
-      <dynamics damping="1.0" friction="3.0"/>
+      <dynamics damping="1.0" friction="0.5"/>
       <origin xyz="0 0 0" rpy="0 0 0"/>
       <parent link="p3at_back_${side}_hub"/>
       <child link="p3at_back_${side}_wheel"/>

--- a/src/b166er_robot/urdf/pioneer3at/pioneer3at-m.urdf.xacro
+++ b/src/b166er_robot/urdf/pioneer3at/pioneer3at-m.urdf.xacro
@@ -209,13 +209,9 @@
       </collision>
     </link>
 
-    <gazebo reference="p3at_front_${side}_wheel">
-      <material value="Gazebo/Black"/>
-      <kp>1000000.0</kp>
-      <kd>100.0</kd>
-      <mu1>0.9</mu1>
-      <mu2>0.9</mu2>
-    </gazebo>
+    <!-- Parâmetros de contato ficam no bloco único mais abaixo (junto do
+         sensor de contato) — blocos <gazebo reference> duplicados para o
+         mesmo link conflitam na fusão do SDF. -->
     <joint name="p3at_front_${side}_wheel_joint" type="continuous">
       <axis xyz="0 1 0"/>
       <anchor xyz="0 0 0"/>
@@ -338,8 +334,11 @@
           </contact>
         </sensor>
         <kp>1000000.0</kp>
-        <!-- kp and kd for rubber -->
-        <kd>100.0</kd>
+        <!-- kd=100 dava razão de amortecimento ~1.6% para os ~41 kg do robô
+             (kd crítico ≈ 6300): o contato quicava a ~50 Hz sem dissipar e a
+             vibração era retificada pelo braço em deslocamento contínuo do
+             chassi (~20-30 mm/s). kd=1e4 → ζ≈1.6 (levemente sobreamortecido). -->
+        <kd>10000.0</kd>
         <mu1>0.9</mu1>
         <!-- was 10 -->
         <mu2>0.9</mu2>
@@ -360,8 +359,8 @@
           </contact>
         </sensor>
         <kp>1000000.0</kp>
-        <!-- kp and kd for rubber -->
-        <kd>100.0</kd>
+        <!-- kd=1e4: ver comentário no bloco da roda traseira. -->
+        <kd>10000.0</kd>
         <mu1>0.9</mu1>
         <!-- was 10 -->
         <mu2>0.9</mu2>

--- a/src/b166er_robot/urdf/pioneer3at/pioneer3at-m.urdf.xacro
+++ b/src/b166er_robot/urdf/pioneer3at/pioneer3at-m.urdf.xacro
@@ -220,7 +220,7 @@
       <axis xyz="0 1 0"/>
       <anchor xyz="0 0 0"/>
       <limit effort="10" velocity="10"/>
-      <joint_properties damping="0.7"/>
+      <dynamics damping="1.0" friction="3.0"/>
       <origin xyz="0 0 0" rpy="0 0 0"/>
       <parent link="p3at_front_${side}_hub"/>
       <child link="p3at_front_${side}_wheel"/>
@@ -268,7 +268,9 @@
         <geometry name="pioneer_geom">
           <mesh filename="package://b166er_robot/meshes/pioneer3at/${side}_hubcap.stl"/>
         </geometry>
-        <material name="HubcapYellow"/>
+        <material name="HubcapYellow">
+          <color rgba="1.0 0.811 0.151 1.0"/>
+        </material>
       </visual>
       <collision>
         <origin xyz="0 0 0" rpy="0 0 0"/>
@@ -302,7 +304,9 @@
         <geometry name="pioneer_geom">
           <mesh filename="package://b166er_robot/meshes/pioneer3at/wheel.stl" scale="0.75 0.66 0.75"/>
         </geometry>
-        <material name="WheelBlack"/>
+        <material name="WheelBlack">
+          <color rgba="0.117 0.117 0.117 1"/>
+        </material>
       </visual>
       <collision>
         <origin xyz="0 0 0" rpy="${-3.1415927/2} 0 0"/>
@@ -321,7 +325,7 @@
       <axis xyz="0 1 0"/>
       <anchor xyz="0 0 0"/>
       <limit effort="10" velocity="10"/>
-      <joint_properties damping="0.7"/>
+      <dynamics damping="1.0" friction="3.0"/>
       <origin xyz="0 0 0" rpy="0 0 0"/>
       <parent link="p3at_back_${side}_hub"/>
       <child link="p3at_back_${side}_wheel"/>
@@ -412,7 +416,7 @@
 
     <gazebo reference="laser_${name}_link">
         <material value="Gazebo/${color}"/>
-        <sensor type="gpu_ray" name="laser_${name}">
+        <sensor type="ray" name="laser_${name}">
           <pose>0 0 0 0 0 0</pose>
           <!-- visualize=true desenha os 1081 raios como disco branco no Gazebo,
                confundindo a inspeção visual do robô. Desabilitado. -->
@@ -442,7 +446,7 @@
               <stddev>0.01</stddev>
             </noise>
           </ray>
-          <plugin name="gazebo_ros_head_hokuyo_controller" filename="libgazebo_ros_gpu_laser.so">
+          <plugin name="gazebo_ros_head_hokuyo_controller" filename="libgazebo_ros_laser.so">
             <topicName>/${robot_name}/laser_${name}/scan</topicName>
             <frameName>laser_${name}_link</frameName>
           </plugin>
@@ -497,8 +501,5 @@
   <xacro:p3at_drive_side side="left" reflect="1"/>
   <xacro:p3at_drive_side side="right" reflect="-1"/>
   <xacro:p3at_gazebo_ext/>
-
-  <!-- contacts and extra robot_state -->
-  <xacro:p3at_gazebo_contacts/>
 
 </robot>

--- a/src/b166er_robot/urdf/pioneer3at/pioneer3at-m.urdf.xacro
+++ b/src/b166er_robot/urdf/pioneer3at/pioneer3at-m.urdf.xacro
@@ -395,7 +395,11 @@
           <geometry>
             <box size="0.025 0.025 0.025"/>
           </geometry>
-          <material name="red"/>
+          <!-- "red" sem <color> = material indefinido no RViz → link renderizado branco.
+               Definição explícita garante cor vermelha em vez do branco padrão. -->
+          <material name="red">
+            <color rgba="0.8 0.1 0.1 1"/>
+          </material>
         </visual>
 
         <inertial>
@@ -410,7 +414,9 @@
         <material value="Gazebo/${color}"/>
         <sensor type="gpu_ray" name="laser_${name}">
           <pose>0 0 0 0 0 0</pose>
-          <visualize>true</visualize>
+          <!-- visualize=true desenha os 1081 raios como disco branco no Gazebo,
+               confundindo a inspeção visual do robô. Desabilitado. -->
+          <visualize>false</visualize>
           <update_rate>40</update_rate>
           <ray>
             <scan>

--- a/src/b166er_robot/worlds/empty.world
+++ b/src/b166er_robot/worlds/empty.world
@@ -9,12 +9,24 @@
     <include>
       <uri>model://ground_plane</uri>
     </include>
-    <!-- Own physics settings to speed up simulation -->
     <physics type='ode'>
-      <max_step_size>0.01</max_step_size>
+      <max_step_size>0.001</max_step_size>
       <real_time_factor>1</real_time_factor>
-      <real_time_update_rate>100</real_time_update_rate>
+      <real_time_update_rate>1000</real_time_update_rate>
       <gravity>0 0 -9.8</gravity>
+      <ode>
+        <solver>
+          <type>quick</type>
+          <iters>50</iters>
+          <sor>1.3</sor>
+        </solver>
+        <constraints>
+          <cfm>0.0</cfm>
+          <erp>0.2</erp>
+          <contact_max_correcting_vel>100.0</contact_max_correcting_vel>
+          <contact_surface_layer>0.001</contact_surface_layer>
+        </constraints>
+      </ode>
     </physics>
   </world>
 </sdf>

--- a/src/b166er_whole_body_control/config/arm_controllers.yaml
+++ b/src/b166er_whole_body_control/config/arm_controllers.yaml
@@ -31,8 +31,8 @@ J5_position_controller:
 # Sem estes, gazebo_ros_control rejeita os controladores de posição
 gazebo_ros_control:
   pid_gains:
-    J1: {p: 100.0, i: 0.0, d: 10.0}
-    J2: {p: 300.0, i: 0.0, d: 30.0}
-    J3: {p: 200.0, i: 0.0, d: 20.0}
-    J4: {p: 100.0, i: 0.0, d: 10.0}
-    J5: {p:  50.0, i: 0.0, d:  5.0}
+    J1: {p: 100.0, i: 0.0, d:  10.0}
+    J2: {p: 300.0, i: 0.0, d:  80.0}   # d: 30→80 — mais amortecimento (J2 carrega mais peso)
+    J3: {p: 200.0, i: 0.0, d:  50.0}   # d: 20→50
+    J4: {p: 100.0, i: 0.0, d:  25.0}   # d: 10→25
+    J5: {p:  50.0, i: 0.0, d:   5.0}

--- a/src/b166er_whole_body_control/config/arm_controllers.yaml
+++ b/src/b166er_whole_body_control/config/arm_controllers.yaml
@@ -31,8 +31,8 @@ J5_position_controller:
 # Sem estes, gazebo_ros_control rejeita os controladores de posição
 gazebo_ros_control:
   pid_gains:
-    J1: {p: 100.0, i: 0.0, d: 10.0}
-    J2: {p: 300.0, i: 0.0, d: 30.0}
-    J3: {p: 200.0, i: 0.0, d: 20.0}
-    J4: {p: 100.0, i: 0.0, d: 10.0}
-    J5: {p:  50.0, i: 0.0, d:  5.0}
+    J1: {p: 100.0, i: 0.0, d: 15.0}
+    J2: {p: 300.0, i: 0.0, d: 48.0}
+    J3: {p: 200.0, i: 0.0, d: 30.0}
+    J4: {p: 100.0, i: 0.0, d: 12.0}
+    J5: {p:  50.0, i: 0.0, d:  6.0}

--- a/src/b166er_whole_body_control/config/arm_controllers.yaml
+++ b/src/b166er_whole_body_control/config/arm_controllers.yaml
@@ -31,8 +31,8 @@ J5_position_controller:
 # Sem estes, gazebo_ros_control rejeita os controladores de posição
 gazebo_ros_control:
   pid_gains:
-    J1: {p: 100.0, i: 0.0, d:  10.0}
-    J2: {p: 300.0, i: 0.0, d:  80.0}   # d: 30→80 — mais amortecimento (J2 carrega mais peso)
-    J3: {p: 200.0, i: 0.0, d:  50.0}   # d: 20→50
-    J4: {p: 100.0, i: 0.0, d:  25.0}   # d: 10→25
-    J5: {p:  50.0, i: 0.0, d:   5.0}
+    J1: {p: 100.0, i: 0.0, d: 10.0}
+    J2: {p: 300.0, i: 0.0, d: 30.0}
+    J3: {p: 200.0, i: 0.0, d: 20.0}
+    J4: {p: 100.0, i: 0.0, d: 10.0}
+    J5: {p:  50.0, i: 0.0, d:  5.0}

--- a/src/b166er_whole_body_control/nodes/arm_controller_loader.py
+++ b/src/b166er_whole_body_control/nodes/arm_controller_loader.py
@@ -2,13 +2,15 @@
 """
 arm_controller_loader — carrega controladores de posição sem esperar por sim_time.
 
-Substitui o spawner padrão que fica preso aguardando /clock em modo gazebo.
-Aguarda o serviço controller_manager/load_controller usando tempo real,
-depois carrega e inicia os controladores, e então despausa o Gazebo.
+Sequência crítica:
+  1. load_controller  (com Gazebo pausado — não depende de física)
+  2. unpause_physics  (física começa a rodar)
+  3. switch_controller (depois do unpause — switch_controller bloqueia
+                        internamente aguardando o loop de física do
+                        gazebo_ros_control; chamar enquanto pausado → deadlock)
 
 O Gazebo é iniciado pausado (paused=true no launch) para garantir que o
 braço não caia sob gravidade antes dos controladores estarem prontos.
-O unpause é garantido via try/finally, mesmo em caso de falha no load.
 """
 
 import time
@@ -44,7 +46,7 @@ def wait_service_real(name, timeout=WAIT_TIMEOUT):
 
 
 def unpause_gazebo():
-    """Despausa o Gazebo. Chamado sempre, mesmo em caso de falha no load."""
+    """Despausa o Gazebo."""
     try:
         if wait_service_real('/gazebo/unpause_physics', timeout=10.0):
             rospy.ServiceProxy('/gazebo/unpause_physics', Empty)()
@@ -61,15 +63,18 @@ def main():
 
     rospy.loginfo('[arm_controller_loader] aguardando controller_manager...')
 
+    loaded = []
+
+    # ── Fase 1: load com Gazebo pausado ────────────────────────────────
+    # load_controller chama init() no plugin, que lê parâmetros e registra
+    # handles de hardware. Não precisa de física rodando.
     try:
         if not wait_service_real('/controller_manager/load_controller'):
             rospy.logerr('[arm_loader] timeout: controller_manager não encontrado')
             return
 
-        load_svc   = rospy.ServiceProxy('/controller_manager/load_controller', LoadController)
-        switch_svc = rospy.ServiceProxy('/controller_manager/switch_controller', SwitchController)
+        load_svc = rospy.ServiceProxy('/controller_manager/load_controller', LoadController)
 
-        loaded = []
         for ctrl in CONTROLLERS:
             try:
                 resp = load_svc(name=ctrl)
@@ -81,21 +86,32 @@ def main():
             except rospy.ServiceException as e:
                 rospy.logerr('[arm_loader] erro ao carregar %s: %s', ctrl, e)
 
-        if loaded:
-            req = SwitchControllerRequest()
-            req.start_controllers = loaded
-            req.stop_controllers  = []
-            req.strictness        = SwitchControllerRequest.BEST_EFFORT
-            if switch_svc(req).ok:
-                rospy.loginfo('[arm_loader] controladores iniciados: %s', loaded)
-            else:
-                rospy.logwarn('[arm_loader] switch_controller retornou False')
-        else:
+        if not loaded:
             rospy.logerr('[arm_loader] nenhum controlador foi carregado')
 
     finally:
-        # Sempre despausa — mesmo se load/switch falharem ou lançarem exceção.
+        # ── Fase 2: unpause ANTES do switch ────────────────────────────
+        # CRÍTICO: switch_controller bloqueia no loop de física do
+        # gazebo_ros_control. Com Gazebo pausado esse loop nunca roda
+        # e o switch nunca retorna → deadlock. O unpause deve vir antes.
         unpause_gazebo()
+
+    # ── Fase 3: switch com física rodando ──────────────────────────────
+    if not loaded:
+        return
+
+    switch_svc = rospy.ServiceProxy('/controller_manager/switch_controller', SwitchController)
+    req = SwitchControllerRequest()
+    req.start_controllers = loaded
+    req.stop_controllers  = []
+    req.strictness        = SwitchControllerRequest.BEST_EFFORT
+    try:
+        if switch_svc(req).ok:
+            rospy.loginfo('[arm_loader] controladores iniciados: %s', loaded)
+        else:
+            rospy.logwarn('[arm_loader] switch_controller retornou False')
+    except rospy.ServiceException as e:
+        rospy.logerr('[arm_loader] erro no switch_controller: %s', e)
 
 
 if __name__ == '__main__':

--- a/src/b166er_whole_body_control/nodes/arm_controller_loader.py
+++ b/src/b166er_whole_body_control/nodes/arm_controller_loader.py
@@ -12,6 +12,7 @@ import rospy
 from controller_manager_msgs.srv import (
     LoadController, SwitchController, SwitchControllerRequest
 )
+from std_srvs.srv import Empty
 
 CONTROLLERS = [
     'joint_state_controller',
@@ -77,6 +78,16 @@ def main():
             rospy.logwarn('[arm_loader] switch_controller retornou False')
     else:
         rospy.logerr('[arm_loader] nenhum controlador foi carregado')
+
+    # Despausa o Gazebo. A simulação foi iniciada pausada para garantir que
+    # o braço não caia sob gravidade antes dos controladores estarem prontos.
+    try:
+        rospy.wait_for_service('/gazebo/unpause_physics', timeout=5.0)
+        unpause = rospy.ServiceProxy('/gazebo/unpause_physics', Empty)
+        unpause()
+        rospy.loginfo('[arm_loader] Gazebo despausado.')
+    except Exception as e:
+        rospy.logwarn('[arm_loader] não foi possível despauser: %s', e)
 
 
 if __name__ == '__main__':

--- a/src/b166er_whole_body_control/nodes/arm_controller_loader.py
+++ b/src/b166er_whole_body_control/nodes/arm_controller_loader.py
@@ -4,10 +4,15 @@ arm_controller_loader — carrega controladores de posição sem esperar por sim
 
 Substitui o spawner padrão que fica preso aguardando /clock em modo gazebo.
 Aguarda o serviço controller_manager/load_controller usando tempo real,
-depois carrega e inicia os controladores.
+depois carrega e inicia os controladores, e então despausa o Gazebo.
+
+O Gazebo é iniciado pausado (paused=true no launch) para garantir que o
+braço não caia sob gravidade antes dos controladores estarem prontos.
+O unpause é garantido via try/finally, mesmo em caso de falha no load.
 """
 
 import time
+import os
 import rospy
 from controller_manager_msgs.srv import (
     LoadController, SwitchController, SwitchControllerRequest
@@ -26,11 +31,9 @@ CONTROLLERS = [
 WAIT_TIMEOUT = 60   # s em tempo real
 
 
-def wait_service(name):
+def wait_service_real(name, timeout=WAIT_TIMEOUT):
     """Aguarda serviço usando tempo real (não sim_time)."""
-    import socket
-    import xmlrpc.client
-    deadline = time.time() + WAIT_TIMEOUT
+    deadline = time.time() + timeout
     while time.time() < deadline:
         try:
             rospy.wait_for_service(name, timeout=2.0)
@@ -40,54 +43,59 @@ def wait_service(name):
     return False
 
 
+def unpause_gazebo():
+    """Despausa o Gazebo. Chamado sempre, mesmo em caso de falha no load."""
+    try:
+        if wait_service_real('/gazebo/unpause_physics', timeout=10.0):
+            rospy.ServiceProxy('/gazebo/unpause_physics', Empty)()
+            rospy.loginfo('[arm_loader] Gazebo despausado.')
+        else:
+            rospy.logerr('[arm_loader] timeout ao aguardar /gazebo/unpause_physics')
+    except Exception as e:
+        rospy.logerr('[arm_loader] falha ao despauser Gazebo: %s', e)
+
+
 def main():
-    # init SEM esperar por sim_time — desativa internamente para não bloquear
-    import os
-    os.environ['ROS_TIME_REAL'] = '1'   # hint; nem sempre funciona em noetic
+    os.environ['ROS_TIME_REAL'] = '1'
     rospy.init_node('arm_controller_loader', disable_rostime=True)
 
     rospy.loginfo('[arm_controller_loader] aguardando controller_manager...')
-    if not wait_service('/controller_manager/load_controller'):
-        rospy.logerr('[arm_loader] timeout: controller_manager não encontrado')
-        return
 
-    load_svc    = rospy.ServiceProxy('/controller_manager/load_controller', LoadController)
-    switch_svc  = rospy.ServiceProxy('/controller_manager/switch_controller', SwitchController)
-
-    loaded = []
-    for ctrl in CONTROLLERS:
-        try:
-            resp = load_svc(name=ctrl)
-            if resp.ok:
-                rospy.loginfo('[arm_loader] carregado: %s', ctrl)
-                loaded.append(ctrl)
-            else:
-                rospy.logwarn('[arm_loader] falha ao carregar: %s', ctrl)
-        except rospy.ServiceException as e:
-            rospy.logerr('[arm_loader] erro ao carregar %s: %s', ctrl, e)
-
-    if loaded:
-        req = SwitchControllerRequest()
-        req.start_controllers = loaded
-        req.stop_controllers  = []
-        req.strictness        = SwitchControllerRequest.BEST_EFFORT
-        resp = switch_svc(req)
-        if resp.ok:
-            rospy.loginfo('[arm_loader] controladores iniciados: %s', loaded)
-        else:
-            rospy.logwarn('[arm_loader] switch_controller retornou False')
-    else:
-        rospy.logerr('[arm_loader] nenhum controlador foi carregado')
-
-    # Despausa o Gazebo. A simulação foi iniciada pausada para garantir que
-    # o braço não caia sob gravidade antes dos controladores estarem prontos.
     try:
-        rospy.wait_for_service('/gazebo/unpause_physics', timeout=5.0)
-        unpause = rospy.ServiceProxy('/gazebo/unpause_physics', Empty)
-        unpause()
-        rospy.loginfo('[arm_loader] Gazebo despausado.')
-    except Exception as e:
-        rospy.logwarn('[arm_loader] não foi possível despauser: %s', e)
+        if not wait_service_real('/controller_manager/load_controller'):
+            rospy.logerr('[arm_loader] timeout: controller_manager não encontrado')
+            return
+
+        load_svc   = rospy.ServiceProxy('/controller_manager/load_controller', LoadController)
+        switch_svc = rospy.ServiceProxy('/controller_manager/switch_controller', SwitchController)
+
+        loaded = []
+        for ctrl in CONTROLLERS:
+            try:
+                resp = load_svc(name=ctrl)
+                if resp.ok:
+                    rospy.loginfo('[arm_loader] carregado: %s', ctrl)
+                    loaded.append(ctrl)
+                else:
+                    rospy.logwarn('[arm_loader] falha ao carregar: %s', ctrl)
+            except rospy.ServiceException as e:
+                rospy.logerr('[arm_loader] erro ao carregar %s: %s', ctrl, e)
+
+        if loaded:
+            req = SwitchControllerRequest()
+            req.start_controllers = loaded
+            req.stop_controllers  = []
+            req.strictness        = SwitchControllerRequest.BEST_EFFORT
+            if switch_svc(req).ok:
+                rospy.loginfo('[arm_loader] controladores iniciados: %s', loaded)
+            else:
+                rospy.logwarn('[arm_loader] switch_controller retornou False')
+        else:
+            rospy.logerr('[arm_loader] nenhum controlador foi carregado')
+
+    finally:
+        # Sempre despausa — mesmo se load/switch falharem ou lançarem exceção.
+        unpause_gazebo()
 
 
 if __name__ == '__main__':

--- a/src/b166er_whole_body_control/nodes/fuzzy_wb_controller.py
+++ b/src/b166er_whole_body_control/nodes/fuzzy_wb_controller.py
@@ -49,6 +49,16 @@ MAX_BASE_ANG = 0.5    # rad/s
 MAX_ARM_VEL  = 0.8    # rad/s por junta
 K_NULL       = 0.3    # ganho do objetivo secundário (espaço nulo)
 
+# Piso de velocidade linear da base. Com o braço horizontal, a direção x do
+# EE é singular para o braço (∂x/∂J2 = 0) e só a base corrige o erro — mas
+# comandos < ~5 mm/s não vencem o escorregamento estático do contato
+# (Gazebo/ODE) nem folgas reais, e a base estaciona fora da tolerância
+# (~7 mm observados). Fora da tolerância, o comando preserva o sentido mas
+# nunca fica abaixo deste módulo. Sem risco de ciclo-limite: a banda de
+# parada (tol_pos=5 mm para cada lado) é maior que o passo por ciclo
+# (10 mm/s ÷ 20 Hz = 0,5 mm).
+MIN_BASE_LIN = 0.010  # m/s
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -76,6 +86,17 @@ def _saturate_base(v_lin, v_ang):
     return v_lin, v_ang
 
 
+def _lin_floor(v):
+    """Aplica o piso MIN_BASE_LIN preservando o sentido.
+
+    Só atua quando o comando é significativo (>1e-5): um v≈0 legítimo
+    (erro ortogonal ao heading, a corrigir por rotação) não é inflado.
+    """
+    if 1e-5 < abs(v) < MIN_BASE_LIN:
+        return MIN_BASE_LIN if v > 0 else -MIN_BASE_LIN
+    return v
+
+
 # ---------------------------------------------------------------------------
 # Nó principal
 # ---------------------------------------------------------------------------
@@ -97,6 +118,7 @@ class FuzzyWBController:
         self._robot_state = None
         self._target      = None
         self._enabled     = False
+        self._reached     = False
 
         # Erro anterior (para derivada)
         self._err_prev  = None
@@ -129,6 +151,7 @@ class FuzzyWBController:
     def _cb_target(self, msg):
         self._target   = _pose_stamped_to_matrix(msg)
         self._enabled  = True
+        self._reached  = False
         self._err_prev = None   # reset derivada ao mudar alvo
         rospy.loginfo('[fuzzy_wb_ctrl] novo alvo: pos=(%.3f, %.3f, %.3f)',
                       msg.pose.position.x,
@@ -167,11 +190,11 @@ class FuzzyWBController:
         if self._nonholo:
             v, w = self._project_nonholo(q_dot_base, theta)
             v, w = _saturate_base(v, w)
-            msg.linear.x  = v
+            msg.linear.x  = _lin_floor(v)
             msg.angular.z = w
         else:
-            msg.linear.x  = float(np.clip(q_dot_base[0], -MAX_BASE_LIN, MAX_BASE_LIN))
-            msg.linear.y  = float(np.clip(q_dot_base[1], -MAX_BASE_LIN, MAX_BASE_LIN))
+            msg.linear.x  = _lin_floor(float(np.clip(q_dot_base[0], -MAX_BASE_LIN, MAX_BASE_LIN)))
+            msg.linear.y  = _lin_floor(float(np.clip(q_dot_base[1], -MAX_BASE_LIN, MAX_BASE_LIN)))
             msg.angular.z = float(np.clip(q_dot_base[2], -MAX_BASE_ANG, MAX_BASE_ANG))
         self._pub_cmdvel.publish(msg)
 
@@ -221,8 +244,15 @@ class FuzzyWBController:
 
             self._update_delta_err(err_total_norm, now)
 
-            # Critério de parada
+            # Critério de parada com histerese: entra em "alcançado" dentro
+            # da tolerância e só reativa se o erro crescer 50% além dela —
+            # evita chaveamento 0 ↔ MIN_BASE_LIN quando o erro paira na borda.
             if err_pos_norm < self._tol_pos and err_orient_norm < self._tol_orient:
+                self._reached = True
+            elif (err_pos_norm > 1.5 * self._tol_pos
+                  or err_orient_norm > 1.5 * self._tol_orient):
+                self._reached = False
+            if self._reached:
                 rospy.loginfo_throttle(2.0,
                     '[fuzzy_wb_ctrl] alvo alcançado — pos=%.4fm ori=%.4frad',
                     err_pos_norm, err_orient_norm)

--- a/src/b166er_whole_body_control/nodes/gazebo_arm_bridge.py
+++ b/src/b166er_whole_body_control/nodes/gazebo_arm_bridge.py
@@ -29,7 +29,7 @@ class GazeboArmBridge:
         rospy.init_node('gazebo_arm_bridge')
 
         self._rate_hz    = rospy.get_param('~rate', 20.0)
-        self._k_ff       = rospy.get_param('~k_gravity_ff', 0.5)
+        self._k_ff       = rospy.get_param('~k_gravity_ff', 1.0)
         self._q_arm      = None          # rad — estado interno (ajustado pelo ff)
         self._dq_cmd     = np.zeros(5)   # rad/s
         self._t_last_cmd = None
@@ -55,12 +55,11 @@ class GazeboArmBridge:
         name_to_pos = dict(zip(msg.name, msg.position))
         if all(n in name_to_pos for n in JOINT_NAMES):
             q_init = np.array([name_to_pos[n] for n in JOINT_NAMES])
-            # q_arm = q_init − q_ff  →  q_pub = q_arm + q_ff = q_init
-            # O braço não se move no warm-start (sem forças de reação na base).
-            q_ff_init  = -self._k_ff * gravity_torque_arm(q_init) / _P_GAINS
-            self._q_arm = np.clip(q_init - q_ff_init, JOINT_LOWER, JOINT_UPPER)
-            rospy.loginfo('[gazebo_arm_bridge] warm-start q_init=%s q_arm=%s rad',
-                          np.round(q_init, 3), np.round(self._q_arm, 3))
+            # q_arm = q_init → q_pub = q_init + q_ff ≈ q_spawn (sem step no PID)
+            # O braço não se move ao fazer takeover: sem forças de reação na base.
+            self._q_arm = np.clip(q_init, JOINT_LOWER, JOINT_UPPER)
+            rospy.loginfo('[gazebo_arm_bridge] warm-start q=%s rad',
+                          np.round(self._q_arm, 3))
 
     def _cb_vel_cmd(self, msg):
         if len(msg.velocity) == 5:
@@ -86,9 +85,9 @@ class GazeboArmBridge:
             self._q_arm = np.clip(self._q_arm + dq * dt,
                                   JOINT_LOWER, JOINT_UPPER)
 
-            # Feedforward de gravidade: offset estático que compensa τ_grav/P.
-            # q_arm é inicializado no warm-start tal que q_pub = q_actual (sem
-            # movimento do braço e sem forças de reação na base no startup).
+            # Feedforward de gravidade: q_pub = q_arm − τ_grav/P compensa o
+            # erro estático do PID. Com k_ff=1 e warm-start q_arm=q_actual,
+            # q_pub ≈ q_spawn → sem step no PID ao fazer takeover.
             tau_g = gravity_torque_arm(self._q_arm)
             q_ff  = -self._k_ff * tau_g / _P_GAINS
             q_pub = np.clip(self._q_arm + q_ff, JOINT_LOWER, JOINT_UPPER)

--- a/src/b166er_whole_body_control/nodes/gazebo_arm_bridge.py
+++ b/src/b166er_whole_body_control/nodes/gazebo_arm_bridge.py
@@ -33,9 +33,9 @@ class GazeboArmBridge:
         self._rate_hz = rospy.get_param('~rate', 20.0)
         self._k_ff    = rospy.get_param('~k_gravity_ff', 1.0)
 
-        # Posição de spawn (deve bater com -J no spawn_model).
+        # Posição de spawn (deve bater com o spawn_model — sem -J, q=0).
         # Usada para calcular o feedforward antes do warm-start real.
-        q_spawn_list  = rospy.get_param('~q_spawn', [0.0, 0.5, 0.0, 0.0, 0.0])
+        q_spawn_list  = rospy.get_param('~q_spawn', [0.0, 0.0, 0.0, 0.0, 0.0])
         self._q_spawn = np.clip(np.array(q_spawn_list, dtype=float),
                                 JOINT_LOWER, JOINT_UPPER)
 

--- a/src/b166er_whole_body_control/nodes/gazebo_arm_bridge.py
+++ b/src/b166er_whole_body_control/nodes/gazebo_arm_bridge.py
@@ -18,7 +18,6 @@ from b166er_whole_body_control.kinematics import (
     JOINT_NAMES, JOINT_LOWER, JOINT_UPPER, gravity_torque_arm)
 
 _VEL_TIMEOUT = 0.5   # s sem comando → zera velocidade
-_FF_RAMP_S   = 2.0   # s para rampar o feedforward de 0 → k_ff (evita degrau no warm-start)
 
 # Ganhos P dos controladores (arm_controllers.yaml) — usados no feedforward
 _P_GAINS = np.array([100.0, 300.0, 200.0, 100.0, 50.0])
@@ -31,10 +30,9 @@ class GazeboArmBridge:
 
         self._rate_hz    = rospy.get_param('~rate', 20.0)
         self._k_ff       = rospy.get_param('~k_gravity_ff', 0.5)
-        self._q_arm      = None          # rad — warm-start do /joint_states
+        self._q_arm      = None          # rad — estado interno (ajustado pelo ff)
         self._dq_cmd     = np.zeros(5)   # rad/s
         self._t_last_cmd = None
-        self._t_warmup   = None          # instante do warm-start (para rampa do ff)
 
         # publicadores para cada controlador de posição
         self._pubs = [
@@ -56,9 +54,13 @@ class GazeboArmBridge:
             return   # warm-start one-shot
         name_to_pos = dict(zip(msg.name, msg.position))
         if all(n in name_to_pos for n in JOINT_NAMES):
-            self._q_arm = np.array([name_to_pos[n] for n in JOINT_NAMES])
-            rospy.loginfo('[gazebo_arm_bridge] warm-start q=%s rad',
-                          np.round(self._q_arm, 3))
+            q_init = np.array([name_to_pos[n] for n in JOINT_NAMES])
+            # q_arm = q_init − q_ff  →  q_pub = q_arm + q_ff = q_init
+            # O braço não se move no warm-start (sem forças de reação na base).
+            q_ff_init  = -self._k_ff * gravity_torque_arm(q_init) / _P_GAINS
+            self._q_arm = np.clip(q_init - q_ff_init, JOINT_LOWER, JOINT_UPPER)
+            rospy.loginfo('[gazebo_arm_bridge] warm-start q_init=%s q_arm=%s rad',
+                          np.round(q_init, 3), np.round(self._q_arm, 3))
 
     def _cb_vel_cmd(self, msg):
         if len(msg.velocity) == 5:
@@ -84,14 +86,11 @@ class GazeboArmBridge:
             self._q_arm = np.clip(self._q_arm + dq * dt,
                                   JOINT_LOWER, JOINT_UPPER)
 
-            # Feedforward de gravidade com rampa: evita degrau no warm-start que
-            # excitaria a ressonância natural do braço. Rampa de _FF_RAMP_S s.
-            if self._t_warmup is None:
-                self._t_warmup = rospy.Time.now()
-            ff_scale = min(1.0, (rospy.Time.now() - self._t_warmup).to_sec()
-                           / _FF_RAMP_S)
+            # Feedforward de gravidade: offset estático que compensa τ_grav/P.
+            # q_arm é inicializado no warm-start tal que q_pub = q_actual (sem
+            # movimento do braço e sem forças de reação na base no startup).
             tau_g = gravity_torque_arm(self._q_arm)
-            q_ff  = -self._k_ff * ff_scale * tau_g / _P_GAINS
+            q_ff  = -self._k_ff * tau_g / _P_GAINS
             q_pub = np.clip(self._q_arm + q_ff, JOINT_LOWER, JOINT_UPPER)
 
             for i, pub in enumerate(self._pubs):

--- a/src/b166er_whole_body_control/nodes/gazebo_arm_bridge.py
+++ b/src/b166er_whole_body_control/nodes/gazebo_arm_bridge.py
@@ -18,6 +18,7 @@ from b166er_whole_body_control.kinematics import (
     JOINT_NAMES, JOINT_LOWER, JOINT_UPPER, gravity_torque_arm)
 
 _VEL_TIMEOUT = 0.5   # s sem comando → zera velocidade
+_FF_RAMP_S   = 2.0   # s para rampar o feedforward de 0 → k_ff (evita degrau no warm-start)
 
 # Ganhos P dos controladores (arm_controllers.yaml) — usados no feedforward
 _P_GAINS = np.array([100.0, 300.0, 200.0, 100.0, 50.0])
@@ -29,10 +30,11 @@ class GazeboArmBridge:
         rospy.init_node('gazebo_arm_bridge')
 
         self._rate_hz    = rospy.get_param('~rate', 20.0)
-        self._k_ff       = rospy.get_param('~k_gravity_ff', 1.0)
+        self._k_ff       = rospy.get_param('~k_gravity_ff', 0.5)
         self._q_arm      = None          # rad — warm-start do /joint_states
         self._dq_cmd     = np.zeros(5)   # rad/s
         self._t_last_cmd = None
+        self._t_warmup   = None          # instante do warm-start (para rampa do ff)
 
         # publicadores para cada controlador de posição
         self._pubs = [
@@ -82,11 +84,14 @@ class GazeboArmBridge:
             self._q_arm = np.clip(self._q_arm + dq * dt,
                                   JOINT_LOWER, JOINT_UPPER)
 
-            # Feedforward de gravidade: offset estático que compensa o erro
-            # de regime τ_grav/P do controlador PID de posição do Gazebo.
-            # q_ff = -τ_grav / P  →  faz o Gazebo segurar a posição desejada.
+            # Feedforward de gravidade com rampa: evita degrau no warm-start que
+            # excitaria a ressonância natural do braço. Rampa de _FF_RAMP_S s.
+            if self._t_warmup is None:
+                self._t_warmup = rospy.Time.now()
+            ff_scale = min(1.0, (rospy.Time.now() - self._t_warmup).to_sec()
+                           / _FF_RAMP_S)
             tau_g = gravity_torque_arm(self._q_arm)
-            q_ff  = -self._k_ff * tau_g / _P_GAINS
+            q_ff  = -self._k_ff * ff_scale * tau_g / _P_GAINS
             q_pub = np.clip(self._q_arm + q_ff, JOINT_LOWER, JOINT_UPPER)
 
             for i, pub in enumerate(self._pubs):

--- a/src/b166er_whole_body_control/nodes/gazebo_arm_bridge.py
+++ b/src/b166er_whole_body_control/nodes/gazebo_arm_bridge.py
@@ -6,7 +6,9 @@ Equivalente ao arm_vel_integrator.py mas para simulação:
   - Integra ẋ_arm (rad/s) → q_arm (rad) via Euler a 20 Hz
   - Publica Float64 individuais para /Jx_position_controller/command
 
-Usa /joint_states do Gazebo como warm-start da posição atual.
+Feedforward de gravidade ativo desde o primeiro ciclo (usando q_spawn)
+para que os controladores nunca vejam erro estático e o braço não caia
+ao inicializar. Após o warm-start com /joint_states, usa q_arm real.
 """
 
 import rospy
@@ -28,13 +30,19 @@ class GazeboArmBridge:
     def __init__(self):
         rospy.init_node('gazebo_arm_bridge')
 
-        self._rate_hz    = rospy.get_param('~rate', 20.0)
-        self._k_ff       = rospy.get_param('~k_gravity_ff', 1.0)
-        self._q_arm      = None          # rad — estado interno (ajustado pelo ff)
-        self._dq_cmd     = np.zeros(5)   # rad/s
+        self._rate_hz = rospy.get_param('~rate', 20.0)
+        self._k_ff    = rospy.get_param('~k_gravity_ff', 1.0)
+
+        # Posição de spawn (deve bater com -J no spawn_model).
+        # Usada para calcular o feedforward antes do warm-start real.
+        q_spawn_list  = rospy.get_param('~q_spawn', [0.0, 0.5, 0.0, 0.0, 0.0])
+        self._q_spawn = np.clip(np.array(q_spawn_list, dtype=float),
+                                JOINT_LOWER, JOINT_UPPER)
+
+        self._q_arm      = None          # rad — None até warm-start real
+        self._dq_cmd     = np.zeros(5)
         self._t_last_cmd = None
 
-        # publicadores para cada controlador de posição
         self._pubs = [
             rospy.Publisher(f'/{n}_position_controller/command',
                             Float64, queue_size=1)
@@ -46,17 +54,22 @@ class GazeboArmBridge:
         rospy.Subscriber('/b166er/arm_vel_cmd', JointState,
                          self._cb_vel_cmd, queue_size=1)
 
-        rospy.loginfo('[gazebo_arm_bridge] aguardando /joint_states para warm-start...')
+        rospy.loginfo('[gazebo_arm_bridge] q_spawn=%s  aguardando warm-start...',
+                      np.round(self._q_spawn, 3))
 
     # ------------------------------------------------------------------
+    def _q_pub_for(self, q_arm):
+        """Posição comandada ao PID: q_arm + feedforward de gravidade."""
+        tau_g = gravity_torque_arm(q_arm)
+        q_ff  = -self._k_ff * tau_g / _P_GAINS
+        return np.clip(q_arm + q_ff, JOINT_LOWER, JOINT_UPPER)
+
     def _cb_joint_states(self, msg):
         if self._q_arm is not None:
             return   # warm-start one-shot
         name_to_pos = dict(zip(msg.name, msg.position))
         if all(n in name_to_pos for n in JOINT_NAMES):
             q_init = np.array([name_to_pos[n] for n in JOINT_NAMES])
-            # q_arm = q_init → q_pub = q_init + q_ff ≈ q_spawn (sem step no PID)
-            # O braço não se move ao fazer takeover: sem forças de reação na base.
             self._q_arm = np.clip(q_init, JOINT_LOWER, JOINT_UPPER)
             rospy.loginfo('[gazebo_arm_bridge] warm-start q=%s rad',
                           np.round(self._q_arm, 3))
@@ -71,8 +84,17 @@ class GazeboArmBridge:
         rate = rospy.Rate(self._rate_hz)
         dt   = 1.0 / self._rate_hz
 
+        # Feedforward pré-calculado para q_spawn: evita queda do braço
+        # antes do warm-start real. Com este comando, o equilíbrio do
+        # PID coincide com q_spawn → nenhuma força de reação na base.
+        q_pub_spawn = self._q_pub_for(self._q_spawn)
+
         while not rospy.is_shutdown():
             if self._q_arm is None:
+                # Publica feedforward de spawn para segurar o braço
+                # enquanto aguarda /joint_states.
+                for i, pub in enumerate(self._pubs):
+                    pub.publish(Float64(data=float(q_pub_spawn[i])))
                 rate.sleep()
                 continue
 
@@ -85,13 +107,7 @@ class GazeboArmBridge:
             self._q_arm = np.clip(self._q_arm + dq * dt,
                                   JOINT_LOWER, JOINT_UPPER)
 
-            # Feedforward de gravidade: q_pub = q_arm − τ_grav/P compensa o
-            # erro estático do PID. Com k_ff=1 e warm-start q_arm=q_actual,
-            # q_pub ≈ q_spawn → sem step no PID ao fazer takeover.
-            tau_g = gravity_torque_arm(self._q_arm)
-            q_ff  = -self._k_ff * tau_g / _P_GAINS
-            q_pub = np.clip(self._q_arm + q_ff, JOINT_LOWER, JOINT_UPPER)
-
+            q_pub = self._q_pub_for(self._q_arm)
             for i, pub in enumerate(self._pubs):
                 pub.publish(Float64(data=float(q_pub[i])))
 

--- a/src/b166er_whole_body_control/nodes/gazebo_arm_bridge.py
+++ b/src/b166er_whole_body_control/nodes/gazebo_arm_bridge.py
@@ -14,9 +14,13 @@ import numpy as np
 from sensor_msgs.msg import JointState
 from std_msgs.msg import Float64
 
-from b166er_whole_body_control.kinematics import JOINT_NAMES, JOINT_LOWER, JOINT_UPPER
+from b166er_whole_body_control.kinematics import (
+    JOINT_NAMES, JOINT_LOWER, JOINT_UPPER, gravity_torque_arm)
 
 _VEL_TIMEOUT = 0.5   # s sem comando → zera velocidade
+
+# Ganhos P dos controladores (arm_controllers.yaml) — usados no feedforward
+_P_GAINS = np.array([100.0, 300.0, 200.0, 100.0, 50.0])
 
 
 class GazeboArmBridge:
@@ -25,6 +29,7 @@ class GazeboArmBridge:
         rospy.init_node('gazebo_arm_bridge')
 
         self._rate_hz    = rospy.get_param('~rate', 20.0)
+        self._k_ff       = rospy.get_param('~k_gravity_ff', 1.0)
         self._q_arm      = None          # rad — warm-start do /joint_states
         self._dq_cmd     = np.zeros(5)   # rad/s
         self._t_last_cmd = None
@@ -77,8 +82,15 @@ class GazeboArmBridge:
             self._q_arm = np.clip(self._q_arm + dq * dt,
                                   JOINT_LOWER, JOINT_UPPER)
 
+            # Feedforward de gravidade: offset estático que compensa o erro
+            # de regime τ_grav/P do controlador PID de posição do Gazebo.
+            # q_ff = -τ_grav / P  →  faz o Gazebo segurar a posição desejada.
+            tau_g = gravity_torque_arm(self._q_arm)
+            q_ff  = -self._k_ff * tau_g / _P_GAINS
+            q_pub = np.clip(self._q_arm + q_ff, JOINT_LOWER, JOINT_UPPER)
+
             for i, pub in enumerate(self._pubs):
-                pub.publish(Float64(data=float(self._q_arm[i])))
+                pub.publish(Float64(data=float(q_pub[i])))
 
             rate.sleep()
 

--- a/src/b166er_whole_body_control/nodes/pioneer_wheel_state_pub.py
+++ b/src/b166er_whole_body_control/nodes/pioneer_wheel_state_pub.py
@@ -29,8 +29,14 @@ def main():
     # bloquearia indefinidamente; WallRate publica sempre a 10 Hz de tempo real.
     rate = rospy.WallRate(10)
     while not rospy.is_shutdown():
+        stamp = rospy.Time.now()
+        # tf2 rejeita transforms com stamp=0 (Gazebo ainda pausado).
+        # Aguarda até o clock avançar antes de publicar.
+        if stamp.is_zero():
+            rate.sleep()
+            continue
         msg = JointState()
-        msg.header.stamp = rospy.Time.now()
+        msg.header.stamp = stamp
         msg.name     = WHEEL_JOINTS
         msg.position = [0.0] * len(WHEEL_JOINTS)
         pub.publish(msg)

--- a/src/b166er_whole_body_control/nodes/pioneer_wheel_state_pub.py
+++ b/src/b166er_whole_body_control/nodes/pioneer_wheel_state_pub.py
@@ -9,7 +9,20 @@ modelo completo do Pioneer.
 
 Este nó publica as 4 rodas a posição=0 para fechar a árvore TF sem
 interferir nos estados reais do braço.
+
+Problema clássico de "roda branca no centro":
+    O joint_state_controller publica J1-J5 no 1.º tick do Gazebo (~1ms
+    após o unpause). Se o roda-pub demora mais que isso para publicar as
+    rodas, robot_state_publisher desconhece a posição das rodas e o RViz
+    renderiza os 4 links de roda na origem do fixed_frame — aparece como
+    um disco branco no centro embaixo do Pioneer.
+
+    Solução: durante a fase pausada fazemos polling rápido (2ms) do
+    clock. Assim que o relógio avança (unpause), publicamos imediatamente
+    — garantindo que robot_state_publisher já conhece as rodas antes de
+    processar o 1.º joint_state do braço.
 """
+import time
 import rospy
 from sensor_msgs.msg import JointState
 
@@ -21,25 +34,36 @@ WHEEL_JOINTS = [
 ]
 
 
+def _publish(pub, stamp):
+    msg = JointState()
+    msg.header.stamp = stamp
+    msg.name = WHEEL_JOINTS
+    msg.position = [0.0] * len(WHEEL_JOINTS)
+    pub.publish(msg)
+
+
 def main():
     rospy.init_node('pioneer_wheel_state_pub')
     pub = rospy.Publisher('/joint_states', JointState, queue_size=1)
 
-    # WallRate: independente de sim_time. Com Gazebo pausado (clock=0), rospy.Rate
-    # bloquearia indefinidamente; WallRate publica sempre a 10 Hz de tempo real.
-    rate = rospy.WallRate(10)
+    # ── Fase 1: polling rápido até o clock avançar (Gazebo despausado) ──
+    # tf2 rejeita transforms com stamp=0 (Gazebo ainda pausado).
+    # Polling a 2ms minimiza a janela sem TF das rodas após o unpause.
     while not rospy.is_shutdown():
         stamp = rospy.Time.now()
-        # tf2 rejeita transforms com stamp=0 (Gazebo ainda pausado).
-        # Aguarda até o clock avançar antes de publicar.
-        if stamp.is_zero():
-            rate.sleep()
-            continue
-        msg = JointState()
-        msg.header.stamp = stamp
-        msg.name     = WHEEL_JOINTS
-        msg.position = [0.0] * len(WHEEL_JOINTS)
-        pub.publish(msg)
+        if not stamp.is_zero():
+            _publish(pub, stamp)
+            rospy.loginfo('[wheel_pub] clock ativo (%.3f s) — rodas publicadas',
+                          stamp.to_sec())
+            break
+        time.sleep(0.002)   # 2ms — independente de sim_time
+
+    # ── Fase 2: manutenção a 50 Hz (WallRate independe de sim_time) ────
+    rate = rospy.WallRate(50)
+    while not rospy.is_shutdown():
+        stamp = rospy.Time.now()
+        if not stamp.is_zero():
+            _publish(pub, stamp)
         rate.sleep()
 
 

--- a/src/b166er_whole_body_control/nodes/pioneer_wheel_state_pub.py
+++ b/src/b166er_whole_body_control/nodes/pioneer_wheel_state_pub.py
@@ -10,7 +10,6 @@ modelo completo do Pioneer.
 Este nó publica as 4 rodas a posição=0 para fechar a árvore TF sem
 interferir nos estados reais do braço.
 """
-import time
 import rospy
 from sensor_msgs.msg import JointState
 
@@ -26,13 +25,9 @@ def main():
     rospy.init_node('pioneer_wheel_state_pub')
     pub = rospy.Publisher('/joint_states', JointState, queue_size=1)
 
-    # Aguarda /clock não-zero para não inundar TF com stamp=0 antes do Gazebo iniciar.
-    # rospy.WallDuration.sleep() usa tempo real — seguro antes do /clock chegar.
-    rospy.loginfo('[pioneer_wheel_state_pub] aguardando /clock...')
-    while not rospy.is_shutdown() and rospy.Time.now().is_zero():
-        time.sleep(0.05)   # wall-time sleep — válido antes do /clock chegar
-
-    rate = rospy.Rate(10)   # 10 Hz é suficiente para rodas estáticas
+    # WallRate: independente de sim_time. Com Gazebo pausado (clock=0), rospy.Rate
+    # bloquearia indefinidamente; WallRate publica sempre a 10 Hz de tempo real.
+    rate = rospy.WallRate(10)
     while not rospy.is_shutdown():
         msg = JointState()
         msg.header.stamp = rospy.Time.now()

--- a/src/b166er_whole_body_control/nodes/pioneer_wheel_state_pub.py
+++ b/src/b166er_whole_body_control/nodes/pioneer_wheel_state_pub.py
@@ -58,13 +58,14 @@ def main():
             break
         time.sleep(0.002)   # 2ms — independente de sim_time
 
-    # ── Fase 2: manutenção a 50 Hz (WallRate independe de sim_time) ────
-    rate = rospy.WallRate(50)
+    # ── Fase 2: manutenção a 50 Hz em tempo de parede ──────────────────
+    # rospy não tem WallRate; time.sleep é o equivalente independente de
+    # sim_time (rospy.Rate bloquearia se o Gazebo pausasse de novo).
     while not rospy.is_shutdown():
         stamp = rospy.Time.now()
         if not stamp.is_zero():
             _publish(pub, stamp)
-        rate.sleep()
+        time.sleep(0.02)
 
 
 if __name__ == '__main__':

--- a/src/b166er_whole_body_control/scripts/plot_shaking.py
+++ b/src/b166er_whole_body_control/scripts/plot_shaking.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""
+plot_shaking.py — plota q(t) e amplitude de oscilação por junta a partir de um rosbag.
+
+Uso:
+  python3 scripts/plot_shaking.py <path/ao/arquivo.bag>
+
+Grava o bag durante o teste:
+  rosbag record -O shaking_test.bag -d 30 /joint_states /b166er/robot_state
+"""
+
+import sys
+import numpy as np
+import matplotlib.pyplot as plt
+
+JOINT_NAMES = ['J1', 'J2', 'J3', 'J4', 'J5']
+
+
+def load_joint_states(bag_path):
+    try:
+        import rosbag
+    except ImportError:
+        print('[ERRO] rosbag não encontrado. Ative o ambiente ROS antes de rodar.')
+        sys.exit(1)
+
+    times = []
+    positions = {n: [] for n in JOINT_NAMES}
+    t0 = None
+
+    with rosbag.Bag(bag_path, 'r') as bag:
+        for _, msg, t in bag.read_messages(topics=['/joint_states']):
+            if t0 is None:
+                t0 = t.to_sec()
+            name_to_pos = dict(zip(msg.name, msg.position))
+            if all(n in name_to_pos for n in JOINT_NAMES):
+                times.append(t.to_sec() - t0)
+                for n in JOINT_NAMES:
+                    positions[n].append(name_to_pos[n])
+
+    return np.array(times), {n: np.array(positions[n]) for n in JOINT_NAMES}
+
+
+def analyse(times, positions):
+    print(f'\n{"Junta":>6}  {"Média (°)":>10}  {"Std (°)":>8}  {"Pico-pico (°)":>14}')
+    print('-' * 46)
+    for n in JOINT_NAMES:
+        q = np.degrees(positions[n])
+        print(f'{n:>6}  {np.mean(q):>10.2f}  {np.std(q):>8.3f}  {np.ptp(q):>14.3f}')
+    print()
+
+
+def plot(times, positions, out_path):
+    fig, axes = plt.subplots(5, 1, figsize=(13, 10), sharex=True)
+    for n, ax in zip(JOINT_NAMES, axes):
+        q_deg = np.degrees(positions[n])
+        ax.plot(times, q_deg, linewidth=0.8)
+        ax.axhline(np.mean(q_deg), color='r', linestyle='--', linewidth=0.6, alpha=0.7)
+        ax.set_ylabel(f'{n} (°)')
+        ax.grid(True, alpha=0.3)
+        ax.set_title(
+            f'{n}  média={np.mean(q_deg):.2f}°  std={np.std(q_deg):.3f}°  '
+            f'pico-pico={np.ptp(q_deg):.3f}°',
+            fontsize=9
+        )
+    axes[-1].set_xlabel('Tempo (s)')
+    fig.suptitle('Oscilação das juntas — q(t)', fontsize=12)
+    plt.tight_layout()
+    plt.savefig(out_path, dpi=150)
+    print(f'Gráfico salvo em: {out_path}')
+    plt.show()
+
+
+def main():
+    if len(sys.argv) < 2:
+        print(__doc__)
+        sys.exit(1)
+
+    bag_path = sys.argv[1]
+    print(f'Lendo {bag_path} ...')
+    times, positions = load_joint_states(bag_path)
+
+    if len(times) == 0:
+        print('[ERRO] Nenhuma mensagem encontrada em /joint_states')
+        sys.exit(1)
+
+    print(f'{len(times)} amostras, duração {times[-1]:.1f} s')
+    analyse(times, positions)
+
+    out_path = bag_path.replace('.bag', '_shaking.png')
+    plot(times, positions, out_path)
+
+
+if __name__ == '__main__':
+    main()

--- a/src/b166er_whole_body_control/src/b166er_whole_body_control/kinematics.py
+++ b/src/b166er_whole_body_control/src/b166er_whole_body_control/kinematics.py
@@ -26,6 +26,10 @@ IK_TOL_ORIENT = 5e-2   # rad — ~3°, suficiente para estimação de estado
 IK_LAMBDA     = 0.02
 IK_DQ_STEP    = 1e-6
 
+# Compensação de gravidade
+_G           = 9.81                                # m/s²
+_LINK_MASSES = np.array([6.3, 5.0, 4.2, 2.5, 1.7])  # L1..L5 kg (do URDF)
+
 
 # ---------------------------------------------------------------------------
 # Primitivas de transformação homogênea (4×4)
@@ -285,3 +289,29 @@ def ik_arm(T_target, q_init=None):
 
     T_cur = fk_arm(q); err = pose_error(T_cur, T_target)
     return q, False, np.linalg.norm(err[:3]), np.linalg.norm(err[3:])
+
+
+# ---------------------------------------------------------------------------
+# Compensação de gravidade
+# ---------------------------------------------------------------------------
+
+def gravity_torque_arm(q):
+    """
+    Torque gravitacional em cada junta do RV-M2 (N·m).
+    Assume frame Base do braço com eixo z alinhado com world up (Pioneer nivelado).
+    CoM de cada elo aproximado na origem do frame da junta filha (consistente
+    com os inertiais do URDF, todos em <origin xyz="0 0 0">).
+
+    Retorna tau_grav (5,) — positivo = direção de aumento do ângulo da junta.
+    """
+    joint_frames, _ = fk_arm_joint_frames(q)
+    p_joints = [T[:3, 3] for T in joint_frames]
+    g_vec = np.array([0.0, 0.0, -_G])
+    tau = np.zeros(5)
+    for i in range(5):
+        z_i = joint_frames[i][:3, 2]   # eixo de rotação da junta i no frame Base
+        p_i = p_joints[i]
+        for j in range(i + 1, 5):      # elos a jusante (CoM em p_joints[j])
+            r = p_joints[j] - p_i
+            tau[i] += _LINK_MASSES[j] * np.dot(g_vec, np.cross(z_i, r))
+    return tau


### PR DESCRIPTION
## Resumo

Conclui a **Fase 3** do ROADMAP: elimina o shaking do braço, o deslocamento espontâneo do Pioneer no Gazebo e as rodas colapsadas no RViz. Pipeline whole-body validado com alvo estático: **erro final de 4,7 mm** (critério: < 5 mm).

### Shaking do braço
- Feedforward de gravidade no `gazebo_arm_bridge` (`gravity_torque_arm` em `kinematics.py`, massas do manual Mitsubishi)
- PIDs por junta dimensionados (`arm_controllers.yaml`), step do mundo 10 ms → 1 ms
- Sequência load → unpause → switch no `arm_controller_loader` (elimina deadlock com Gazebo pausado)

### Rodas colapsadas no RViz ("roda branca")
- Causa raiz: `rospy.WallRate` **não existe** — o `pioneer_wheel_state_pub` morria após 1 publish e o RViz nunca recebia o TF das rodas (4 links renderizados na origem)
- Corrigido com loop wall-time (`time.sleep`), imune a pausas do sim_time

### Deslocamento espontâneo do Pioneer
Diagnóstico ao vivo na simulação (serviços do Gazebo + `/gazebo/link_states`):
- Robô inteiro em queda perpétua (vz ≈ -0.08 m/s) — ciclo-limite de quicar do contato
- Causa: contato subamortecido (kp=1e6, kd=100 → ζ ≈ 1,6% para ~41 kg); o braço horizontal retificava a vibração em avanço contínuo (~20-30 mm/s)
- Correções: **kd 100 → 1e4** nas 4 rodas; remoção de bloco `<gazebo reference>` duplicado; spawn a 1 mm do chão; spawn em q=0 (o `-J J2 0.5` corria contra o unpause e gerava pico de ~150 N·m no chassi)

### Ajuste fino do controlador whole-body
- Piso de velocidade da base (`MIN_BASE_LIN=10 mm/s`): comandos menores giravam as rodas mas não transladavam a base (micro-patinagem no contato ODE), estacionando a 7,2 mm do alvo
- Histerese no critério de parada (reativa só com erro > 1,5×tol) — sem chaveamento na borda da tolerância
- Correções auxiliares: plugin skid-steer real (`libgazebo_ros_skid_steer_drive.so`), laser `gpu_ray` → `ray`, cores explícitas nos materiais, remoção do plugin de contatos inexistente

## Validação (medida no Gazebo)

| Critério | Resultado |
|---|---|
| Amplitude de oscilação < 0.05 rad | ✅ dq ≈ 0.0002 rad/s |
| IK converge ≥ 60 s contínuos | ✅ `ik_converged` estável |
| EE tracking < 5 mm (alvo estático) | ✅ 4,7 mm, `cmd_vel=0` após alcançar |

**Limitação conhecida** (registrada no ROADMAP): alvos com erro puramente lateral estacionam a ~99 mm — a projeção não-holonômica não gera esterçamento e a estratégia de manobra é decisão de projeto em aberto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)