### PR TITLE
feat(vision): pacote b166er_vision — detecção AprilTag nas fisheye da T265

### DIFF
--- a/src/b166er_vision/CMakeLists.txt
+++ b/src/b166er_vision/CMakeLists.txt
@@ -1,0 +1,16 @@
+cmake_minimum_required(VERSION 3.5)
+project(b166er_vision)
+
+find_package(catkin REQUIRED)
+
+catkin_python_setup()
+
+catkin_package(
+  CATKIN_DEPENDS
+)
+
+catkin_install_python(
+  PROGRAMS
+    nodes/apriltag_detector.py
+  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)

--- a/src/b166er_vision/config/apriltag_detector.yaml
+++ b/src/b166er_vision/config/apriltag_detector.yaml
@@ -1,0 +1,23 @@
+# Parâmetros do apriltag_detector (servovisão Fase 4)
+# Regra do projeto: nada de hardcoding — tudo aqui.
+
+# Tópicos da T265 (realsense2_camera com enable_fisheye1:=true)
+image_topic: /t265/fisheye1/image_raw
+camera_info_topic: /t265/fisheye1/camera_info
+
+# Lado do quadrado PRETO externo do tag impresso, em metros.
+# Com 848×800 e FOV ~163°, usar >= 0.10 m para detecção confiável a ~0.5 m.
+tag_size: 0.10
+
+# ID do tag alvo (família 36h11). -1 = usa o de menor erro de reprojeção.
+target_tag_id: 0
+
+# Escala da focal da pinhole virtual (1.0 = mesma resolução angular
+# central do fisheye ≈ 112° de FOV útil; >1 aproxima e reduz o FOV)
+pinhole_zoom: 1.0
+
+# Rejeita poses com erro médio de reprojeção acima disso (pixels)
+max_reproj_error_px: 2.0
+
+# Publica ~debug_image com os tags desenhados (custo de CPU; só p/ ajuste)
+publish_debug_image: false

--- a/src/b166er_vision/launch/apriltag_detector.launch
+++ b/src/b166er_vision/launch/apriltag_detector.launch
@@ -1,0 +1,13 @@
+<launch>
+  <!-- Detector de AprilTag nas fisheye da T265 (servovisão Fase 4).
+       Pré-requisito: realsense2_camera rodando com enable_fisheye1:=true. -->
+
+  <arg name="config" default="$(find b166er_vision)/config/apriltag_detector.yaml"/>
+  <arg name="debug"  default="false"/>
+
+  <node name="apriltag_detector" pkg="b166er_vision"
+        type="apriltag_detector.py" output="screen">
+    <rosparam command="load" file="$(arg config)"/>
+    <param name="publish_debug_image" value="$(arg debug)"/>
+  </node>
+</launch>

--- a/src/b166er_vision/nodes/apriltag_detector.py
+++ b/src/b166er_vision/nodes/apriltag_detector.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""apriltag_detector — pose de AprilTag a partir das fisheye da T265.
+
+Assina a fisheye crua da T265, retifica (Kannala-Brandt → pinhole
+virtual) e detecta tags 36h11, publicando:
+
+  • /b166er/tag_pose   (PoseStamped)  — pose do tag ALVO no frame óptico
+                                        da câmera (frame_id do header da
+                                        imagem), para a servovisão.
+  • TF                                — <frame da câmera> → tag_<id>,
+                                        para todos os tags detectados.
+  • ~debug_image       (Image, mono8) — retificada com tags desenhados
+                                        (só se ~publish_debug_image).
+
+Parâmetros (ver config/apriltag_detector.yaml):
+  ~image_topic, ~camera_info_topic, ~tag_size, ~target_tag_id,
+  ~pinhole_zoom, ~publish_debug_image, ~max_reproj_error_px
+
+A conversão Image↔numpy é manual (mono8) para não depender do cv_bridge.
+"""
+
+from typing import Optional
+
+import cv2
+import numpy as np
+import rospy
+import tf2_ros
+from geometry_msgs.msg import PoseStamped, TransformStamped
+from sensor_msgs.msg import CameraInfo, Image
+
+from b166er_vision.fisheye_apriltag import (
+    AprilTagDetector,
+    FisheyeRectifier,
+    TagDetection,
+    select_tag,
+)
+
+
+def _rotation_to_quaternion(R: np.ndarray) -> np.ndarray:
+    """Matriz 3×3 → quaternion [x, y, z, w] (método de Shepperd)."""
+    q = np.empty(4)
+    trace = np.trace(R)
+    if trace > 0.0:
+        s = np.sqrt(trace + 1.0) * 2.0
+        q[3] = 0.25 * s
+        q[0] = (R[2, 1] - R[1, 2]) / s
+        q[1] = (R[0, 2] - R[2, 0]) / s
+        q[2] = (R[1, 0] - R[0, 1]) / s
+    else:
+        i = int(np.argmax(np.diag(R)))
+        j, k = (i + 1) % 3, (i + 2) % 3
+        s = np.sqrt(R[i, i] - R[j, j] - R[k, k] + 1.0) * 2.0
+        q[i] = 0.25 * s
+        q[j] = (R[j, i] + R[i, j]) / s
+        q[k] = (R[k, i] + R[i, k]) / s
+        q[3] = (R[k, j] - R[j, k]) / s
+    return q / np.linalg.norm(q)
+
+
+def _image_to_mono8(msg: Image) -> Optional[np.ndarray]:
+    """sensor_msgs/Image → np.ndarray mono8 (sem cv_bridge)."""
+    if msg.encoding in ('mono8', '8UC1'):
+        img = np.frombuffer(msg.data, dtype=np.uint8)
+        return img.reshape(msg.height, msg.step)[:, : msg.width]
+    if msg.encoding in ('bgr8', 'rgb8'):
+        img = np.frombuffer(msg.data, dtype=np.uint8)
+        img = img.reshape(msg.height, msg.step // 3, 3)[:, : msg.width, :]
+        code = cv2.COLOR_BGR2GRAY if msg.encoding == 'bgr8' else cv2.COLOR_RGB2GRAY
+        return cv2.cvtColor(img, code)
+    rospy.logwarn_throttle(
+        10.0, '[apriltag] encoding não suportado: %s', msg.encoding
+    )
+    return None
+
+
+class AprilTagNode:
+
+    def __init__(self) -> None:
+        rospy.init_node('apriltag_detector')
+
+        image_topic = rospy.get_param(
+            '~image_topic', '/t265/fisheye1/image_raw'
+        )
+        info_topic = rospy.get_param(
+            '~camera_info_topic', '/t265/fisheye1/camera_info'
+        )
+        self._tag_size = float(rospy.get_param('~tag_size', 0.10))
+        self._target_id = int(rospy.get_param('~target_tag_id', -1))
+        self._zoom = float(rospy.get_param('~pinhole_zoom', 1.0))
+        self._debug = bool(rospy.get_param('~publish_debug_image', False))
+        self._max_reproj = float(rospy.get_param('~max_reproj_error_px', 2.0))
+
+        self._rectifier: Optional[FisheyeRectifier] = None
+        self._detector: Optional[AprilTagDetector] = None
+
+        self._pub_pose = rospy.Publisher(
+            '/b166er/tag_pose', PoseStamped, queue_size=1
+        )
+        self._pub_debug = (
+            rospy.Publisher('~debug_image', Image, queue_size=1)
+            if self._debug else None
+        )
+        self._tf_broadcaster = tf2_ros.TransformBroadcaster()
+
+        rospy.Subscriber(info_topic, CameraInfo, self._cb_info, queue_size=1)
+        rospy.Subscriber(
+            image_topic, Image, self._cb_image,
+            queue_size=1, buff_size=2 ** 22,
+        )
+
+        rospy.loginfo(
+            '[apriltag] aguardando %s (tag_size=%.3f m, alvo=%s)',
+            info_topic, self._tag_size,
+            self._target_id if self._target_id >= 0 else 'qualquer',
+        )
+
+    # ------------------------------------------------------------------
+    def _cb_info(self, msg: CameraInfo) -> None:
+        """One-shot: monta retificador + detector a partir do CameraInfo."""
+        if self._rectifier is not None:
+            return
+        if msg.distortion_model not in ('equidistant', 'fisheye'):
+            rospy.logwarn(
+                '[apriltag] modelo de distorção "%s" (esperado equidistant); '
+                'retificando mesmo assim com D[:4]', msg.distortion_model,
+            )
+        K = np.array(msg.K, dtype=np.float64).reshape(3, 3)
+        D = np.array(msg.D[:4], dtype=np.float64)
+        self._rectifier = FisheyeRectifier(
+            K, D, (msg.width, msg.height), zoom=self._zoom
+        )
+        self._detector = AprilTagDetector(
+            self._rectifier.pinhole_K, self._tag_size
+        )
+        rospy.loginfo(
+            '[apriltag] retificador pronto (%dx%d, fx_pinhole=%.1f)',
+            msg.width, msg.height, self._rectifier.pinhole_K[0, 0],
+        )
+
+    # ------------------------------------------------------------------
+    def _cb_image(self, msg: Image) -> None:
+        if self._rectifier is None or self._detector is None:
+            return   # ainda sem CameraInfo
+
+        gray = _image_to_mono8(msg)
+        if gray is None:
+            return
+
+        rectified = self._rectifier.rectify(gray)
+        detections = [
+            d for d in self._detector.detect(rectified)
+            if d.reproj_error_px <= self._max_reproj
+        ]
+
+        for det in detections:
+            self._broadcast_tf(det, msg)
+
+        target = select_tag(detections, self._target_id)
+        if target is not None:
+            self._pub_pose.publish(self._to_pose_msg(target, msg))
+
+        if self._pub_debug is not None:
+            self._publish_debug(rectified, detections, msg)
+
+    # ------------------------------------------------------------------
+    def _to_pose_msg(self, det: TagDetection, img_msg: Image) -> PoseStamped:
+        q = _rotation_to_quaternion(det.R_cam_tag)
+        pose = PoseStamped()
+        pose.header.stamp = img_msg.header.stamp
+        pose.header.frame_id = img_msg.header.frame_id
+        pose.pose.position.x = det.t_cam_tag[0]
+        pose.pose.position.y = det.t_cam_tag[1]
+        pose.pose.position.z = det.t_cam_tag[2]
+        (pose.pose.orientation.x, pose.pose.orientation.y,
+         pose.pose.orientation.z, pose.pose.orientation.w) = q
+        return pose
+
+    def _broadcast_tf(self, det: TagDetection, img_msg: Image) -> None:
+        q = _rotation_to_quaternion(det.R_cam_tag)
+        t = TransformStamped()
+        t.header.stamp = img_msg.header.stamp
+        t.header.frame_id = img_msg.header.frame_id
+        t.child_frame_id = f'tag_{det.tag_id}'
+        t.transform.translation.x = det.t_cam_tag[0]
+        t.transform.translation.y = det.t_cam_tag[1]
+        t.transform.translation.z = det.t_cam_tag[2]
+        (t.transform.rotation.x, t.transform.rotation.y,
+         t.transform.rotation.z, t.transform.rotation.w) = q
+        self._tf_broadcaster.sendTransform(t)
+
+    def _publish_debug(self, rectified, detections, img_msg: Image) -> None:
+        canvas = cv2.cvtColor(rectified, cv2.COLOR_GRAY2BGR)
+        for det in detections:
+            pts = det.corners_px.astype(np.int32)
+            cv2.polylines(canvas, [pts], True, (0, 255, 0), 2)
+            cv2.putText(
+                canvas, f'id={det.tag_id} z={det.t_cam_tag[2]:.2f}m',
+                tuple(pts[0]), cv2.FONT_HERSHEY_SIMPLEX, 0.6, (0, 255, 0), 2,
+            )
+        out = Image()
+        out.header = img_msg.header
+        out.height, out.width = canvas.shape[:2]
+        out.encoding = 'bgr8'
+        out.step = out.width * 3
+        out.data = canvas.tobytes()
+        self._pub_debug.publish(out)
+
+
+if __name__ == '__main__':
+    try:
+        AprilTagNode()
+        rospy.spin()
+    except rospy.ROSInterruptException:
+        pass

--- a/src/b166er_vision/package.xml
+++ b/src/b166er_vision/package.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>b166er_vision</name>
+  <version>0.1.0</version>
+  <description>
+    Visual perception for b166er servoing.
+    Rectifies the T265 fisheye stream (Kannala-Brandt model) into a virtual
+    pinhole image and detects AprilTag (36h11) fiducials, publishing tag pose
+    and TF for the Fuzzy whole-body visual servoing loop (no depth camera:
+    the T265 is the only RealSense on the robot).
+  </description>
+
+  <maintainer email="marco.a.reis@gmail.com">Marco Reis</maintainer>
+  <license>MIT</license>
+
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <exec_depend>rospy</exec_depend>
+  <exec_depend>std_msgs</exec_depend>
+  <exec_depend>geometry_msgs</exec_depend>
+  <exec_depend>sensor_msgs</exec_depend>
+  <exec_depend>tf2_ros</exec_depend>
+</package>

--- a/src/b166er_vision/setup.py
+++ b/src/b166er_vision/setup.py
@@ -1,0 +1,9 @@
+from distutils.core import setup
+from catkin_pkg.python_setup import generate_distutils_setup
+
+d = generate_distutils_setup(
+    packages=['b166er_vision'],
+    package_dir={'': 'src'},
+)
+
+setup(**d)

--- a/src/b166er_vision/src/b166er_vision/fisheye_apriltag.py
+++ b/src/b166er_vision/src/b166er_vision/fisheye_apriltag.py
@@ -1,0 +1,188 @@
+"""Pipeline de visão para servovisão: fisheye T265 → pinhole virtual → AprilTag.
+
+As fisheye da T265 (OV9282, 848×800 mono, FOV ~163°) usam o modelo de
+distorção Kannala-Brandt ("equidistant" no CameraInfo), que os detectores
+de marcadores não entendem. O pipeline:
+
+    1. FisheyeRectifier: retifica a imagem para uma câmera pinhole virtual
+       (cv2.fisheye) — os mapas são pré-computados uma única vez.
+    2. AprilTagDetector: detecta tags 36h11 (cv2.aruco, sem dependências
+       novas) na imagem retificada e estima pose 6-DOF via solvePnP
+       (IPPE_SQUARE) com a intrínseca pinhole virtual.
+
+Módulo puro (NumPy + OpenCV): sem ROS, testável com pytest.
+"""
+
+from dataclasses import dataclass
+from typing import List, Optional, Tuple
+
+import cv2
+import numpy as np
+
+
+@dataclass
+class TagDetection:
+    """Uma detecção de AprilTag com pose no frame da câmera.
+
+    Convenção: eixo z da câmera aponta para fora da lente; ``t_cam_tag``
+    é a posição do centro do tag no frame da câmera (m); ``R_cam_tag``
+    leva vetores do frame do tag para o frame da câmera.
+
+    ``pose_ambiguity`` ∈ [0, 1]: razão erro_melhor/erro_segunda das duas
+    soluções do IPPE (ambiguidade de pose planar). Próximo de 1 = as duas
+    soluções explicam os cantos igualmente bem → a ORIENTAÇÃO não é
+    confiável (a posição permanece boa). Consumidores que dependem da
+    orientação devem filtrar por este campo.
+    """
+
+    tag_id: int
+    corners_px: np.ndarray          # (4, 2) cantos na imagem retificada
+    t_cam_tag: np.ndarray           # (3,) m
+    R_cam_tag: np.ndarray           # (3, 3)
+    reproj_error_px: float
+    pose_ambiguity: float
+
+
+class FisheyeRectifier:
+    """Retifica imagens fisheye (Kannala-Brandt) para pinhole virtual.
+
+    A pinhole virtual é construída EXPLICITAMENTE a partir do fx do
+    fisheye (mesma resolução angular central), não via
+    ``estimateNewCameraMatrixForUndistortRectify`` — com FOV muito largo
+    (T265 ≈ 163°) essa função degenera e devolve focal minúscula
+    (fx 285 → 58), encolhendo os marcadores até ficarem indetectáveis.
+
+    Com fx≈285 e 848 px de largura, a retificada cobre
+    2·atan(424/285) ≈ 112° de FOV útil — suficiente para servoing.
+
+    Args:
+        K: intrínseca fisheye 3×3 (do CameraInfo.K).
+        D: 4 coeficientes Kannala-Brandt (do CameraInfo.D[:4]).
+        size: (largura, altura) da imagem de entrada.
+        zoom: escala da focal virtual (1.0 = mesma resolução angular
+            central do fisheye; >1 aproxima, reduzindo o FOV coberto).
+    """
+
+    def __init__(
+        self,
+        K: np.ndarray,
+        D: np.ndarray,
+        size: Tuple[int, int],
+        zoom: float = 1.0,
+    ) -> None:
+        if zoom <= 0.0:
+            raise ValueError(f'zoom deve ser positivo, veio {zoom}')
+        self._size = size
+        K = np.asarray(K, dtype=np.float64).reshape(3, 3)
+        D = np.asarray(D, dtype=np.float64).reshape(4, 1)
+
+        f_virtual = K[0, 0] * zoom
+        self.pinhole_K: np.ndarray = np.array(
+            [[f_virtual, 0.0, K[0, 2]],
+             [0.0, f_virtual, K[1, 2]],
+             [0.0, 0.0, 1.0]]
+        )
+        self._map1, self._map2 = cv2.fisheye.initUndistortRectifyMap(
+            K, D, np.eye(3), self.pinhole_K, size, cv2.CV_16SC2
+        )
+
+    def rectify(self, image: np.ndarray) -> np.ndarray:
+        """Imagem fisheye → imagem pinhole virtual (mesma resolução)."""
+        return cv2.remap(
+            image, self._map1, self._map2, interpolation=cv2.INTER_LINEAR
+        )
+
+
+class AprilTagDetector:
+    """Detecta AprilTags 36h11 e estima pose com solvePnP IPPE_SQUARE.
+
+    Args:
+        pinhole_K: intrínseca 3×3 da imagem retificada (sem distorção).
+        tag_size: lado do quadrado PRETO externo do tag, em metros.
+    """
+
+    def __init__(self, pinhole_K: np.ndarray, tag_size: float) -> None:
+        if tag_size <= 0.0:
+            raise ValueError(f'tag_size deve ser positivo, veio {tag_size}')
+        self._K = np.asarray(pinhole_K, dtype=np.float64).reshape(3, 3)
+        self._tag_size = tag_size
+
+        dictionary = cv2.aruco.getPredefinedDictionary(
+            cv2.aruco.DICT_APRILTAG_36h11
+        )
+        params = cv2.aruco.DetectorParameters()
+        # Refino subpixel dos cantos melhora bastante a pose a distância
+        params.cornerRefinementMethod = cv2.aruco.CORNER_REFINE_SUBPIX
+        self._detector = cv2.aruco.ArucoDetector(dictionary, params)
+
+        # Cantos 3D do tag no frame do próprio tag (z=0, ordem do aruco:
+        # top-left, top-right, bottom-right, bottom-left)
+        half = tag_size / 2.0
+        self._obj_pts = np.array(
+            [
+                [-half,  half, 0.0],
+                [ half,  half, 0.0],
+                [ half, -half, 0.0],
+                [-half, -half, 0.0],
+            ],
+            dtype=np.float64,
+        )
+
+    def detect(self, gray: np.ndarray) -> List[TagDetection]:
+        """Detecta todos os tags 36h11 numa imagem retificada (mono8)."""
+        corners, ids, _ = self._detector.detectMarkers(gray)
+        if ids is None:
+            return []
+
+        detections: List[TagDetection] = []
+        for tag_corners, tag_id in zip(corners, ids.flatten()):
+            img_pts = tag_corners.reshape(4, 2).astype(np.float64)
+            # IPPE tem 2 soluções (ambiguidade de pose planar). O solvePnP
+            # simples pode devolver o ramo errado; o Generic devolve ambas
+            # com os erros — escolhemos a melhor e medimos a ambiguidade.
+            n_sol, rvecs, tvecs, errs = cv2.solvePnPGeneric(
+                self._obj_pts,
+                img_pts,
+                self._K,
+                None,   # imagem retificada: sem distorção
+                flags=cv2.SOLVEPNP_IPPE_SQUARE,
+            )
+            if n_sol < 1:
+                continue
+
+            errs = np.asarray(errs, dtype=np.float64).flatten()
+            best = int(np.argmin(errs))
+            if n_sol > 1:
+                second = float(np.partition(errs, 1)[1])
+                ambiguity = (
+                    float(errs[best]) / second if second > 1e-12 else 1.0
+                )
+            else:
+                ambiguity = 0.0
+
+            R, _ = cv2.Rodrigues(rvecs[best])
+            detections.append(
+                TagDetection(
+                    tag_id=int(tag_id),
+                    corners_px=img_pts,
+                    t_cam_tag=tvecs[best].flatten(),
+                    R_cam_tag=R,
+                    reproj_error_px=float(errs[best]),
+                    pose_ambiguity=ambiguity,
+                )
+            )
+        return detections
+
+
+def select_tag(
+    detections: List[TagDetection], target_id: int
+) -> Optional[TagDetection]:
+    """Seleciona o tag alvo (target_id < 0 → o de menor erro de reprojeção)."""
+    if not detections:
+        return None
+    if target_id >= 0:
+        for det in detections:
+            if det.tag_id == target_id:
+                return det
+        return None
+    return min(detections, key=lambda d: d.reproj_error_px)

--- a/src/b166er_vision/test/test_fisheye_apriltag.py
+++ b/src/b166er_vision/test/test_fisheye_apriltag.py
@@ -1,0 +1,214 @@
+"""Testes end-to-end do pipeline fisheye → pinhole → AprilTag → pose.
+
+Sem hardware e sem ROS: renderiza um tag 36h11 numa pose 3D conhecida,
+sintetiza a imagem FISHEYE correspondente (modelo Kannala-Brandt com
+coeficientes típicos da T265) e verifica que o pipeline completo
+recupera a pose com erro pequeno.
+"""
+
+from typing import Tuple
+
+import cv2
+import numpy as np
+import pytest
+
+from b166er_vision.fisheye_apriltag import (
+    AprilTagDetector,
+    FisheyeRectifier,
+    select_tag,
+)
+
+# ── Câmera sintética no espírito da T265 ───────────────────────────────
+SIZE: Tuple[int, int] = (848, 800)
+K_FISHEYE = np.array(
+    [[285.0, 0.0, 424.0],
+     [0.0, 285.0, 400.0],
+     [0.0, 0.0, 1.0]]
+)
+D_FISHEYE = np.array([-0.008, 0.045, -0.043, 0.008])   # ordem de grandeza T265
+
+TAG_SIZE = 0.10   # m
+TAG_ID = 3
+
+
+def _render_tag_pinhole(
+    pinhole_K: np.ndarray, rvec: np.ndarray, tvec: np.ndarray
+) -> np.ndarray:
+    """Renderiza o tag (com borda branca) visto por uma câmera pinhole."""
+    dictionary = cv2.aruco.getPredefinedDictionary(cv2.aruco.DICT_APRILTAG_36h11)
+    marker_px = 300
+    marker = cv2.aruco.generateImageMarker(dictionary, TAG_ID, marker_px)
+
+    # Borda branca de 1 módulo (36h11 tem 8 módulos de lado no quadrado preto)
+    module = marker_px // 8
+    marker = cv2.copyMakeBorder(
+        marker, module, module, module, module,
+        cv2.BORDER_CONSTANT, value=255,
+    )
+    border_m = TAG_SIZE / 8.0
+
+    # Cantos 3D do marcador COM borda, no frame do tag (ordem TL, TR, BR, BL
+    # igual à imagem gerada: y para baixo na imagem = -y no frame do tag)
+    half = TAG_SIZE / 2.0 + border_m
+    obj = np.array(
+        [[-half,  half, 0.0],
+         [ half,  half, 0.0],
+         [ half, -half, 0.0],
+         [-half, -half, 0.0]],
+        dtype=np.float64,
+    )
+    img_pts, _ = cv2.projectPoints(obj, rvec, tvec, pinhole_K, None)
+    img_pts = img_pts.reshape(4, 2).astype(np.float32)
+
+    src = np.array(
+        [[0, 0], [marker.shape[1], 0],
+         [marker.shape[1], marker.shape[0]], [0, marker.shape[0]]],
+        dtype=np.float32,
+    )
+    H = cv2.getPerspectiveTransform(src, img_pts)
+    canvas = np.full((SIZE[1], SIZE[0]), 128, dtype=np.uint8)
+    warped = cv2.warpPerspective(
+        marker, H, SIZE, canvas,
+        borderMode=cv2.BORDER_TRANSPARENT,
+    )
+    return warped
+
+
+def _distort_to_fisheye(
+    pinhole_img: np.ndarray, pinhole_K: np.ndarray
+) -> np.ndarray:
+    """Sintetiza a imagem fisheye a partir da imagem pinhole.
+
+    Para cada pixel da imagem fisheye de saída, encontra a coordenada
+    correspondente na imagem pinhole (undistortPoints com P=pinhole_K)
+    e faz remap — o inverso exato do que o FisheyeRectifier faz.
+    """
+    w, h = SIZE
+    xs, ys = np.meshgrid(np.arange(w, dtype=np.float32),
+                         np.arange(h, dtype=np.float32))
+    fisheye_px = np.stack([xs, ys], axis=-1).reshape(-1, 1, 2)
+
+    pinhole_px = cv2.fisheye.undistortPoints(
+        fisheye_px, K_FISHEYE, D_FISHEYE.reshape(4, 1),
+        R=np.eye(3), P=pinhole_K,
+    ).reshape(h, w, 2)
+
+    return cv2.remap(
+        pinhole_img,
+        pinhole_px[..., 0], pinhole_px[..., 1],
+        interpolation=cv2.INTER_LINEAR,
+        borderMode=cv2.BORDER_CONSTANT, borderValue=128,
+    )
+
+
+@pytest.fixture(scope='module')
+def rectifier() -> FisheyeRectifier:
+    return FisheyeRectifier(K_FISHEYE, D_FISHEYE, SIZE, zoom=1.0)
+
+
+def _rvec_flip_and_tilt(tilt_y_deg: float, tilt_x_deg: float = 0.0) -> np.ndarray:
+    """rvec do tag de frente pra câmera (flip x) + inclinação decisiva.
+
+    Inclinação >= 15° separa bem os dois ramos do IPPE (ambiguidade de
+    pose planar); com o tag quase frontal os ramos colapsam e a
+    orientação deixa de ser testável de forma determinística.
+    """
+    flip, _ = cv2.Rodrigues(np.array([np.pi, 0.0, 0.0]))
+    tilt, _ = cv2.Rodrigues(
+        np.array([np.radians(tilt_x_deg), np.radians(tilt_y_deg), 0.0])
+    )
+    rvec, _ = cv2.Rodrigues(flip @ tilt)
+    return rvec.flatten()
+
+
+@pytest.mark.parametrize(
+    'tvec_true, rvec_true',
+    [
+        (np.array([0.00, 0.00, 0.45]), _rvec_flip_and_tilt(15.0)),
+        (np.array([0.10, -0.05, 0.55]), _rvec_flip_and_tilt(-20.0)),
+        (np.array([-0.08, 0.06, 0.50]), _rvec_flip_and_tilt(25.0, 10.0)),
+    ],
+    ids=['centro-15deg', 'deslocado-20deg', 'canto-25deg'],
+)
+def test_pipeline_recupera_pose(
+    rectifier: FisheyeRectifier,
+    tvec_true: np.ndarray,
+    rvec_true: np.ndarray,
+) -> None:
+    """fisheye sintética → rectify → detect → pose ≈ ground truth."""
+    pinhole = _render_tag_pinhole(rectifier.pinhole_K, rvec_true, tvec_true)
+    fisheye = _distort_to_fisheye(pinhole, rectifier.pinhole_K)
+
+    rectified = rectifier.rectify(fisheye)
+    detector = AprilTagDetector(rectifier.pinhole_K, TAG_SIZE)
+    detections = detector.detect(rectified)
+
+    assert detections, 'nenhum tag detectado na imagem retificada'
+    det = select_tag(detections, TAG_ID)
+    assert det is not None, f'tag {TAG_ID} não encontrado'
+
+    # Posição: erro < 2% da distância
+    dist = float(np.linalg.norm(tvec_true))
+    pos_err = float(np.linalg.norm(det.t_cam_tag - tvec_true))
+    assert pos_err < 0.02 * dist, (
+        f'erro de posição {pos_err*1000:.1f} mm a {dist:.2f} m'
+    )
+
+    # Orientação: ângulo do erro rotacional < 3°
+    R_true, _ = cv2.Rodrigues(rvec_true)
+    R_err = det.R_cam_tag.T @ R_true
+    angle = float(np.degrees(np.arccos(
+        np.clip((np.trace(R_err) - 1.0) / 2.0, -1.0, 1.0)
+    )))
+    assert angle < 3.0, f'erro de orientação {angle:.2f}°'
+
+    assert det.reproj_error_px < 1.0
+    # Inclinação decisiva → ramo correto do IPPE vence com folga
+    assert det.pose_ambiguity < 0.8, (
+        f'pose ambígua (razão {det.pose_ambiguity:.2f}) em pose inclinada'
+    )
+
+
+def test_frontal_posicao_boa_mesmo_com_ambiguidade(
+    rectifier: FisheyeRectifier,
+) -> None:
+    """Tag quase frontal: posição confiável; ambiguidade é reportada.
+
+    Documenta o comportamento que o consumidor (servovisão) deve
+    conhecer: de frente, a ORIENTAÇÃO pode vir do ramo errado do IPPE,
+    mas a POSIÇÃO permanece precisa — filtrar orientação por
+    ``pose_ambiguity``.
+    """
+    tvec_true = np.array([0.0, 0.0, 0.5])
+    rvec_true = np.array([np.pi, 0.0, 0.0])
+
+    pinhole = _render_tag_pinhole(rectifier.pinhole_K, rvec_true, tvec_true)
+    fisheye = _distort_to_fisheye(pinhole, rectifier.pinhole_K)
+    detector = AprilTagDetector(rectifier.pinhole_K, TAG_SIZE)
+    det = select_tag(detector.detect(rectifier.rectify(fisheye)), TAG_ID)
+
+    assert det is not None
+    pos_err = float(np.linalg.norm(det.t_cam_tag - tvec_true))
+    assert pos_err < 0.01, f'erro de posição {pos_err*1000:.1f} mm'
+    assert 0.0 <= det.pose_ambiguity <= 1.0
+
+
+def test_select_tag_prefere_id_alvo(rectifier: FisheyeRectifier) -> None:
+    """select_tag com id >= 0 retorna só o alvo; ausente → None."""
+    pinhole = _render_tag_pinhole(
+        rectifier.pinhole_K,
+        np.array([np.pi, 0.0, 0.0]),
+        np.array([0.0, 0.0, 0.5]),
+    )
+    detector = AprilTagDetector(rectifier.pinhole_K, TAG_SIZE)
+    detections = detector.detect(pinhole)
+    assert detections
+
+    assert select_tag(detections, TAG_ID) is not None
+    assert select_tag(detections, TAG_ID + 1) is None
+    assert select_tag([], -1) is None
+
+
+def test_tag_size_invalido(rectifier: FisheyeRectifier) -> None:
+    with pytest.raises(ValueError):
+        AprilTagDetector(rectifier.pinhole_K, 0.0)


### PR DESCRIPTION
## Resumo

Novo pacote **`b166er_vision`**: pipeline de percepção para a servovisão da Fase 4, usando a única câmera do robô (T265, sem profundidade). Núcleo puro NumPy/OpenCV testável sem ROS; nó ROS como casca fina; **zero dependências novas** (o cv2.aruco do ambiente já traz o dicionário AprilTag 36h11).

## Arquitetura

```
/t265/fisheye1/image_raw ─┐
/t265/fisheye1/camera_info ┤→ [apriltag_detector] → /b166er/tag_pose (PoseStamped)
                           │                       → TF: <frame óptico> → tag_<id>
                           └                       → ~debug_image (opcional)
```

- **FisheyeRectifier** — Kannala-Brandt ("equidistant") → pinhole virtual. A pinhole é construída explicitamente a partir do fx do fisheye (≈112° de FOV útil). Descoberto no desenvolvimento: `estimateNewCameraMatrixForUndistortRectify` **degenera com o FOV de 163° da T265** (devolvia fx 285→58, encolhendo os tags até ficarem indetectáveis).
- **AprilTagDetector** — 36h11 com refino subpixel; pose via `solvePnPGeneric` IPPE_SQUARE escolhendo a solução de menor reprojeção e expondo **`pose_ambiguity`** (razão entre os dois ramos do IPPE). Com o tag quase frontal os ramos colapsam e a orientação pode vir do ramo errado — a posição permanece precisa; consumidores que dependem de orientação filtram por esse campo.
- **Nó** — parâmetros 100% em YAML (regra do projeto), conversão Image↔numpy manual (sem cv_bridge), filtro por erro de reprojeção.

## Testes (6 passed, sem ROS nem hardware)

Renderiza um tag em pose 3D conhecida, **sintetiza a imagem fisheye** (distorção inversa exata do modelo K-B com coeficientes típicos da T265) e roda o pipeline completo:

- Pose recuperada com erro < 2% em posição e < 3° em orientação (3 poses: centro/deslocado/canto, 15-25° de inclinação)
- Caso frontal documentado: posição < 10 mm mesmo com ambiguidade de orientação
- Seleção de tag alvo e validação de parâmetros

```
PYTHONPATH=src python3 -m pytest test/ -v   # no diretório do pacote
============================== 6 passed in 0.40s ===============================
```

## Uso (Fase 4, com a T265 real)

```bash
roslaunch b166er_vision apriltag_detector.launch          # produção
roslaunch b166er_vision apriltag_detector.launch debug:=true  # com imagem anotada
```

Pré-requisito: `realsense2_camera` com `enable_fisheye1:=true`. Tag impresso ≥ 10 cm (limite da resolução angular das fisheye: ~0,2°/pixel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)